### PR TITLE
Packaging the lib classes in the plugin jar/hpi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-## Temporary workaround to run the plugin
-Please use this argument when running Jenkins `-Dhudson.remoting.ClassFilter=io.jenkins.plugins.report.jtreg.model.Report,io.jenkins.plugins.report.jtreg.model.ReportFull,io.jenkins.plugins.report.jtreg.model.Suite,io.jenkins.plugins.report.jtreg.model.Test,io.jenkins.plugins.report.jtreg.model.TestOutput`. This the consequence of the recent refactoring and it's actively being worked on.
-
 # jenkins-report-jtreg
 Jenkins plugin to show unit-test, tesng, jtreg and JCK reports summaries, diffs and details
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Temporary workaround to run the plugin
+Please use this argument when running Jenkins `-Dhudson.remoting.ClassFilter=io.jenkins.plugins.report.jtreg.model.Report,io.jenkins.plugins.report.jtreg.model.ReportFull,io.jenkins.plugins.report.jtreg.model.Suite,io.jenkins.plugins.report.jtreg.model.Test,io.jenkins.plugins.report.jtreg.model.TestOutput`. This the consequence of the recent refactoring and it's actively being worked on.
+
 # jenkins-report-jtreg
 Jenkins plugin to show unit-test, tesng, jtreg and JCK reports summaries, diffs and details
 

--- a/report-jtreg-plugin/pom.xml
+++ b/report-jtreg-plugin/pom.xml
@@ -32,6 +32,54 @@
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>report-jtreg-lib</artifactId>
             <version>${revision}${changelist}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <properties>
+                <script.extension>.sh</script.extension>
+            </properties>
+        </profile>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <script.extension>.bat</script.extension>
+            </properties>
+        </profile>
+    </profiles>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copying-lib-into-plugin-on-unix</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>./script${script.extension}</executable>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/report-jtreg-plugin/pom.xml
+++ b/report-jtreg-plugin/pom.xml
@@ -45,7 +45,7 @@
                 </os>
             </activation>
             <properties>
-                <script.extension>.sh</script.extension>
+                <script.execution>./script.sh</script.execution>
             </properties>
         </profile>
         <profile>
@@ -56,7 +56,7 @@
                 </os>
             </activation>
             <properties>
-                <script.extension>.bat</script.extension>
+                <script.execution>.\script.bat</script.execution>
             </properties>
         </profile>
     </profiles>
@@ -75,7 +75,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <executable>./script${script.extension}</executable>
+                            <executable>${script.execution}</executable>
                         </configuration>
                     </execution>
                 </executions>

--- a/report-jtreg-plugin/script.bat
+++ b/report-jtreg-plugin/script.bat
@@ -1,0 +1,16 @@
+::
+:: Why is this here?
+:: After refactoring the codebase of this plugin into multiple modules, the report-jtreg-lib remained as a dependency
+:: to the report-jtreg-plugin module (the Jenkins plugin itself). However, because of the Jenkins security hardening
+:: (https://www.jenkins.io/blog/2018/03/15/jep-200-lts/), the plugin can't load classes from external modules and it
+:: throws an class filter exception. After trying many different solutions to the problem, this seemed like the only
+:: doable workaround.
+::
+:: What does this do?
+:: This script is run in the compile phase of the report-jtreg-plugin module (the report-jtreg-lib module is already
+:: compiled) and it copies the target folder of the lib module to the target folder of the plugin module. Since the
+:: report-jtreg-lib dependency has the "provided" scope, the classes do not clash and the plugin works as intended with
+:: the lib classes in the plugin jar/hpi.
+::
+
+xcopy /E /Y ..\report-jtreg-lib\target\* target\

--- a/report-jtreg-plugin/script.sh
+++ b/report-jtreg-plugin/script.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+#
+# Why is this here?
+# After refactoring the codebase of this plugin into multiple modules, the report-jtreg-lib remained as a dependency
+# to the report-jtreg-plugin module (the Jenkins plugin itself). However, because of the Jenkins security hardening
+# (https://www.jenkins.io/blog/2018/03/15/jep-200-lts/), the plugin can't load classes from external modules and it
+# throws an class filter exception. After trying many different solutions to the problem, this seemed like the only
+# doable workaround.
+#
+# What does this do?
+# This script is run in the compile phase of the report-jtreg-plugin module (the report-jtreg-lib module is already
+# compiled) and it copies the target folder of the lib module to the target folder of the plugin module. Since the
+# report-jtreg-lib dependency has the "provided" scope, the classes do not clash and the plugin works as intended with
+# the lib classes in the plugin jar/hpi.
+#
+
+cp -arv ../report-jtreg-lib/target/* target


### PR DESCRIPTION
Copied explanation from the script.sh file:
```
# Why is this here?
# After refactoring the codebase of this plugin into multiple modules, the report-jtreg-lib remained as a dependency
# to the report-jtreg-plugin module (the Jenkins plugin itself). However, because of the Jenkins security hardening
# (https://www.jenkins.io/blog/2018/03/15/jep-200-lts/), the plugin can't load classes from external modules and it
# throws an class filter exception. After trying many different solutions to the problem, this seemed like the only
# doable workaround.
#
# What does this do?
# This script is run in the compile phase of the report-jtreg-plugin module (the report-jtreg-lib module is already
# compiled) and it copies the target folder of the lib module to the target folder of the plugin module. Since the
# report-jtreg-lib dependency has the "provided" scope, the classes do not clash and the plugin works as intended with
# the lib classes in the plugin jar/hpi.
```

The compiling works only on Linux for now, but I will add Windows support very soon.