### PR TITLE
Correcting comparator tests and changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-## Temporary workaround to run the plugin
-Please use this argument when running Jenkins `-Dhudson.remoting.ClassFilter=io.jenkins.plugins.report.jtreg.model.Report,io.jenkins.plugins.report.jtreg.model.ReportFull,io.jenkins.plugins.report.jtreg.model.Suite,io.jenkins.plugins.report.jtreg.model.Test,io.jenkins.plugins.report.jtreg.model.TestOutput`. This the consequence of the recent refactoring and it's actively being worked on.
-
 # jenkins-report-jtreg
 Jenkins plugin to show unit-test, tesng, jtreg and JCK reports summaries, diffs and details
 
@@ -20,6 +17,7 @@ The plugin reads archived gzipped xml files prdoduced by junit/testng/jtreg/jck 
 * [Limitations](#limitations)
 * [Diff cli tool](#diff-cli-tool)
 * [Future work](#future-work)
+* [For developers](#for-developers)
 
 ## Implementation details
 The xml reports you recieve, should be post processed a bit, and compressed.  Compressed, as plugin is used with reports hundrets of megabytes large. And postprocessed as various engines generates various reports. Thus the xml files should be gathered into archives, which are later considered as suites:
@@ -131,3 +129,9 @@ Html output is much more clumsy, but the listing of switches and jobs is live, a
 * make cli more user friendly
 
 This plugin depends on https://github.com/judovana/jenkins-chartjs-plugin
+
+## For developers
+In the compile phase of the `report-jtreg-plugin` module a `script.sh/.bat` is run. The script copies the `target` directory of the already compiled `jtreg-report-lib` module into the `target` directory of the plugin module.
+This is done because of the Jenkins security hardening (https://www.jenkins.io/blog/2018/03/15/jep-200-lts/). The plugin can't load classes from external modules, and it throws a class filter exception.
+
+The plugin should work correctly with this "workaround", however, if it doesn't, run Jenkins with this switch, it should solve the problem: `-Dhudson.remoting.ClassFilter=io.jenkins.plugins.report.jtreg.model.Report,io.jenkins.plugins.report.jtreg.model.ReportFull,io.jenkins.plugins.report.jtreg.model.Suite,io.jenkins.plugins.report.jtreg.model.Test,io.jenkins.plugins.report.jtreg.model.TestOutput`

--- a/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/JobsByQueryTest.java
+++ b/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/JobsByQueryTest.java
@@ -200,6 +200,12 @@ public class JobsByQueryTest {
         Assertions.assertTrue(containsJobs.contains("reproducers~regular-jp17-ojdk17~rpms-f36.x86_64-fastdebug.sdk-f36.x86_64.vagrant-x11.defaultgc.defaultcp.lnxagent.jfroff"));
     }
 
+    private String crlfToLf(String s) {
+        // replaces windows CRLF newline to unix LF newline
+        // needed for the tests to pass both on linux and windows
+        return s.replace("\r\n", "\n");
+    }
+
     @Test
     public void testPrintJobs() {
         ByteArrayOutputStream outStream = new ByteArrayOutputStream();
@@ -215,7 +221,7 @@ public class JobsByQueryTest {
         JobsPrinting.printJobs(jbq.getJobs(), false, "", 0, formatter, false);
 
         Assertions.assertEquals("crypto~tests-jp11-ojdk11~rpms-f36.x86_64-fastdebug.sdk-f36.x86_64.vagrant-x11.defaultgc.fips.lnxagent.jfroff:\n" +
-                "reproducers~regular-jp17-ojdk17~rpms-f36.x86_64-fastdebug.sdk-f36.x86_64.vagrant-x11.defaultgc.defaultcp.lnxagent.jfroff:\n", outStream.toString());
+                "reproducers~regular-jp17-ojdk17~rpms-f36.x86_64-fastdebug.sdk-f36.x86_64.vagrant-x11.defaultgc.defaultcp.lnxagent.jfroff:\n", crlfToLf(outStream.toString()));
     }
 
     @Test
@@ -247,6 +253,6 @@ public class JobsByQueryTest {
                 "12) defaultgc, shenandoah, \n" +
                 "13) ignorecp, \n" +
                 "14) lnxagent, \n" +
-                "15) jfroff, jfron, \n", outStream.toString());
+                "15) jfroff, jfron, \n", crlfToLf(outStream.toString()));
     }
 }

--- a/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
+++ b/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
@@ -6,7 +6,6 @@ import io.jenkins.plugins.report.jtreg.formatters.HtmlFormatter;
 import io.jenkins.plugins.report.jtreg.formatters.PlainFormatter;
 import org.junit.jupiter.api.*;
 
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
@@ -21,6 +20,12 @@ public class PrintTableTest {
                 {"third row", null, "", "X"},
                 {"fourth row", "X", "X", "X", "this is out of range and it won't be shown"}
         };
+    }
+
+    private String crlfToLf(String s) {
+        // replaces windows CRLF newline to unix LF newline
+        // needed for the tests to pass both on linux and windows
+        return s.replace("\r\n", "\n");
     }
 
     @Test
@@ -39,7 +44,8 @@ public class PrintTableTest {
                 "           | 1 | 2                                                    | 3 | \n" +
                 "second row | X | this is a very long text in a center cell of a table | X | \n" +
                 "third row  |   |                                                      | X | \n" +
-                "fourth row | X | X                                                    | X | \n", outStream.toString());
+                "fourth row | X | X                                                    | X | \n",
+                crlfToLf(outStream.toString()));
     }
 
     @Test
@@ -56,7 +62,8 @@ public class PrintTableTest {
                 "           | \u001B[1m1\u001B[0m | \u001B[1m2\u001B[0m                                                    | \u001B[1m3\u001B[0m | \n" +
                 "second row | \u001B[31mX\u001B[0m | this is a very long text in a center cell of a table | \u001B[31mX\u001B[0m | \n" +
                 "third row  |   |                                                      | \u001B[31mX\u001B[0m | \n" +
-                "fourth row | \u001B[31mX\u001B[0m | \u001B[31mX\u001B[0m                                                    | \u001B[31mX\u001B[0m | \n", outStream.toString());
+                "fourth row | \u001B[31mX\u001B[0m | \u001B[31mX\u001B[0m                                                    | \u001B[31mX\u001B[0m | \n",
+                crlfToLf(outStream.toString()));
     }
 
     @Test
@@ -98,6 +105,7 @@ public class PrintTableTest {
                 "<td style=\"color:Red\">X</td>\n" +
                 "<td style=\"color:Red\">X</td>\n" +
                 "</tr>\n" +
-                "</table>\n", outStream.toString());
+                "</table>\n",
+                crlfToLf(outStream.toString()));
     }
 }


### PR DESCRIPTION
Corrected the `JobsByQueryTest` and `PrintTableTest` tests to also work on Windows (added `crlfToLf()` method) and also edited the readme file.