### PR TITLE
Comparator Jenkins intergration

### DIFF
--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -55,7 +55,7 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
     public String createComparatorLinkUrl(String comparatorUrl, LinkToComparator ltc) {
         StringBuilder url = new StringBuilder();
 
-        for (String arg : ltc.getComparatorArguments().split(System.lineSeparator())) {
+        for (String arg : ltc.getComparatorArguments().split("(\\n|\\r\\n)")) {
             url.append(parseQueryToText(ltc.getSpliterator(), arg));
             url.append(" ");
         }

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -54,13 +54,8 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
         StringBuilder url = new StringBuilder(getCompUrlStub());
 
         for (String arg : ltc.getComparatorArguments().split("\n")) {
-            if (arg.matches("^-+regex.*")) {
-                url.append("--regex+");
-                url.append(parseToRegex(ltc.getSpliterator(), arg.split(" ")[1])); // split the arg my space and give it the second part
-            } else {
-                url.append(arg);
-                url.append("+");
-            }
+            url.append(parseQueryToText(ltc.getSpliterator(), arg));
+            url.append(" ");
         }
 
         return url.toString()
@@ -69,7 +64,7 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
                 .replace(".", "%2E");
     }
 
-    private String parseToRegex(String spliterator, String query) {
+    private String parseQueryToText(String spliterator, String query) {
         String[] splitJob = job.split(spliterator);
 
         String converted = query;
@@ -100,7 +95,7 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
                 replacement = splitJob[number];
             }
 
-            converted = converted.replaceFirst("%\\{((N-)?[0-9]+|S|SPLIT)\\}", replacement);
+            converted = m.replaceFirst(replacement);
             m = p.matcher(converted);
         }
 

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -75,7 +75,7 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
         String converted = query;
 
         // finds %N in the query from Jenkins config and replaces it with corresponding part of job name
-        Pattern p = Pattern.compile("%\\{((N\\+|N-)?[0-9]+|S|SPLIT)\\}");
+        Pattern p = Pattern.compile("%\\{((N-)?[0-9]+|S|SPLIT)\\}");
         Matcher m = p.matcher(converted);
 
         while (m.find()) {
@@ -92,10 +92,15 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
                     number = Integer.parseInt(insideBrackets) - 1;
                 }
 
+                if (number < 0 || number >= splitJob.length) {
+                    System.err.println("WARNING: The number given in the --regex argument of \"Comparator links\" section is out of range of the job name!");
+                    return "The number given is out of range of the job name!";
+                }
+
                 replacement = splitJob[number];
             }
 
-            converted = converted.replaceFirst("%\\{((N\\+|N-)?[0-9]+|S|SPLIT)\\}", replacement);
+            converted = converted.replaceFirst("%\\{((N-)?[0-9]+|S|SPLIT)\\}", replacement);
             m = p.matcher(converted);
         }
 

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -52,15 +52,15 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
         return matchedComparatorLinksGroup;
     }
 
-    public String createComparatorLinkUrl(LinkToComparator ltc) {
+    public String createComparatorLinkUrl(String comparatorUrl, LinkToComparator ltc) {
         StringBuilder url = new StringBuilder();
 
-        for (String arg : ltc.getComparatorArguments().split("\n")) {
+        for (String arg : ltc.getComparatorArguments().split(System.lineSeparator())) {
             url.append(parseQueryToText(ltc.getSpliterator(), arg));
             url.append(" ");
         }
 
-        return getCompUrlStub() + URLEncoder.encode(url.toString(), StandardCharsets.UTF_8);
+        return comparatorUrl + URLEncoder.encode(url.toString(), StandardCharsets.UTF_8);
     }
 
     private String parseQueryToText(String spliterator, String query) {
@@ -121,7 +121,7 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
         return SuiteTestsWithResultsPlugin.getDiffServer() + "?generated-part=+-view%3Dinfo+++-output%3Dhtml++&custom-part=";//+job+numbers //eg as above;
     }
 
-    private static String getCompUrlStub() {
+    public static String getCompUrlStub() {
         return SuiteTestsWithResultsPlugin.getCompServer() + "?generated-part=&custom-part=";
     }
 

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -25,6 +25,8 @@ package io.jenkins.plugins.report.jtreg;
 
 import io.jenkins.plugins.report.jtreg.model.*;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -51,17 +53,14 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
     }
 
     public String createComparatorLinkUrl(LinkToComparator ltc) {
-        StringBuilder url = new StringBuilder(getCompUrlStub());
+        StringBuilder url = new StringBuilder();
 
         for (String arg : ltc.getComparatorArguments().split("\n")) {
             url.append(parseQueryToText(ltc.getSpliterator(), arg));
             url.append(" ");
         }
 
-        return url.toString()
-                .replace(" ", "+")
-                .replace("#", "%23")
-                .replace(".", "%2E");
+        return getCompUrlStub() + URLEncoder.encode(url.toString(), StandardCharsets.UTF_8);
     }
 
     private String parseQueryToText(String spliterator, String query) {
@@ -69,7 +68,7 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
 
         String converted = query;
 
-        // finds %N in the query from Jenkins config and replaces it with corresponding part of job name
+        // finds %{X} in the query from Jenkins config and replaces it with corresponding part of job name
         Pattern p = Pattern.compile("%\\{((N-)?[0-9]+|S|SPLIT)\\}");
         Matcher m = p.matcher(converted);
 

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -39,15 +39,15 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
         this.job = job;
     }
 
-    public List<ComparatorLinks> getMatchedComparatorLinks() {
-        List<ComparatorLinks> matchedComparatorLinks = new ArrayList<>();
-        for (ComparatorLinks link : JenkinsReportJckGlobalConfig.getGlobalComparatorLinks()) {
+    public List<ComparatorLinksGroup> getMatchedComparatorLinksGroups() {
+        List<ComparatorLinksGroup> matchedComparatorLinksGroup = new ArrayList<>();
+        for (ComparatorLinksGroup link : JenkinsReportJckGlobalConfig.getGlobalComparatorLinksGroups()) {
             if (job.matches(link.getJobMatchRegex())) {
-                matchedComparatorLinks.add(link);
+                matchedComparatorLinksGroup.add(link);
             }
         }
 
-        return matchedComparatorLinks;
+        return matchedComparatorLinksGroup;
     }
 
     public String createComparatorLinkUrl(LinkToComparator ltc) {

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -69,7 +69,7 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
         String converted = query;
 
         // finds %{X} in the query from Jenkins config and replaces it with corresponding part of job name
-        Pattern p = Pattern.compile("%\\{((N-)?[0-9]+|S|SPLIT)\\}");
+        Pattern p = Pattern.compile("%\\{(N?[+-]?[0-9]+|N|S|SPLIT)\\}");
         Matcher m = p.matcher(converted);
 
         while (m.find()) {
@@ -80,8 +80,10 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
                 replacement = spliterator;
             } else {
                 int number;
-                if (insideBrackets.charAt(0) == 'N') {
+                if (insideBrackets.charAt(0) == 'N' && insideBrackets.length() > 1) {
                     number = splitJob.length + Integer.parseInt(insideBrackets.substring(1));
+                } else if (insideBrackets.charAt(0) == 'N') {
+                    number = splitJob.length;
                 } else {
                     number = Integer.parseInt(insideBrackets) - 1;
                 }

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/ComparatorLinks.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/ComparatorLinks.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.report.jtreg;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.util.List;
+
+public class ComparatorLinks extends AbstractDescribableImpl<ComparatorLinks> {
+    private String jobMatchRegex;
+    private List<LinkToComparator> links;
+
+    @DataBoundConstructor
+    public ComparatorLinks(String jobMatchRegex, List<LinkToComparator> links) {
+        this.jobMatchRegex = jobMatchRegex;
+        this.links = links;
+    }
+
+    public String getJobMatchRegex() {
+        return jobMatchRegex;
+    }
+    @DataBoundSetter
+    public void setJobMatchRegex(String jobMatchRegex) {
+        this.jobMatchRegex = jobMatchRegex;
+    }
+
+    public List<LinkToComparator> getLinks() {
+        return links;
+    }
+    @DataBoundSetter
+    public void setLinks(List<LinkToComparator> links) {
+        this.links = links;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ComparatorLinks> {
+        public String getDisplayName() { return "Comparator links"; }
+    }
+
+}

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/ComparatorLinksGroup.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/ComparatorLinksGroup.java
@@ -8,12 +8,12 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.List;
 
-public class ComparatorLinks extends AbstractDescribableImpl<ComparatorLinks> {
+public class ComparatorLinksGroup extends AbstractDescribableImpl<ComparatorLinksGroup> {
     private String jobMatchRegex;
     private List<LinkToComparator> links;
 
     @DataBoundConstructor
-    public ComparatorLinks(String jobMatchRegex, List<LinkToComparator> links) {
+    public ComparatorLinksGroup(String jobMatchRegex, List<LinkToComparator> links) {
         this.jobMatchRegex = jobMatchRegex;
         this.links = links;
     }
@@ -35,7 +35,7 @@ public class ComparatorLinks extends AbstractDescribableImpl<ComparatorLinks> {
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<ComparatorLinks> {
+    public static class DescriptorImpl extends Descriptor<ComparatorLinksGroup> {
         public String getDisplayName() { return "Comparator links"; }
     }
 

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
@@ -18,7 +18,7 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
     private static Logger logger = Logger.getLogger(JenkinsReportJckGlobalConfig.class.getName());
 
     String diffToolUrl;
-    List<ComparatorLinks> comparatorLinks;
+    List<ComparatorLinksGroup> comparatorLinkGroups;
 
     public static JenkinsReportJckGlobalConfig getInstance() {
         return GlobalConfiguration.all().get(JenkinsReportJckGlobalConfig.class);
@@ -49,23 +49,23 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
         this.diffToolUrl = diffToolUrl;
     }
 
-    public static List<ComparatorLinks> getGlobalComparatorLinks() {
-        return getInstance().getComparatorLinks();
+    public static List<ComparatorLinksGroup> getGlobalComparatorLinksGroups() {
+        return getInstance().getComparatorLinksGroups();
     }
 
-    public List<ComparatorLinks> getComparatorLinks() {
-        return comparatorLinks;
+    public List<ComparatorLinksGroup> getComparatorLinksGroups() {
+        return comparatorLinkGroups;
     }
 
     @DataBoundSetter
-    public void setComparatorLinks(List<ComparatorLinks> comparatorLinks) {
-        this.comparatorLinks = comparatorLinks;
+    public void setComparatorLinksGroups(List<ComparatorLinksGroup> comparatorLinkGroups) {
+        this.comparatorLinkGroups = comparatorLinkGroups;
     }
 
     @DataBoundConstructor
-    public JenkinsReportJckGlobalConfig(String diffToolUrl, List<ComparatorLinks> comparatorLinks) {
+    public JenkinsReportJckGlobalConfig(String diffToolUrl, List<ComparatorLinksGroup> comparatorLinkGroups) {
         this.diffToolUrl = diffToolUrl;
-        this.comparatorLinks = comparatorLinks;
+        this.comparatorLinkGroups = comparatorLinkGroups;
     }
 
     public JenkinsReportJckGlobalConfig() {

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
@@ -18,7 +18,7 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
     private static Logger logger = Logger.getLogger(JenkinsReportJckGlobalConfig.class.getName());
 
     String diffToolUrl;
-    List<ComparatorLinksGroup> comparatorLinkGroups;
+    List<ComparatorLinksGroup> comparatorLinksGroups;
 
     public static JenkinsReportJckGlobalConfig getInstance() {
         return GlobalConfiguration.all().get(JenkinsReportJckGlobalConfig.class);
@@ -54,18 +54,18 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
     }
 
     public List<ComparatorLinksGroup> getComparatorLinksGroups() {
-        return comparatorLinkGroups;
+        return comparatorLinksGroups;
     }
 
     @DataBoundSetter
-    public void setComparatorLinksGroups(List<ComparatorLinksGroup> comparatorLinkGroups) {
-        this.comparatorLinkGroups = comparatorLinkGroups;
+    public void setComparatorLinksGroups(List<ComparatorLinksGroup> comparatorLinksGroups) {
+        this.comparatorLinksGroups = comparatorLinksGroups;
     }
 
     @DataBoundConstructor
-    public JenkinsReportJckGlobalConfig(String diffToolUrl, List<ComparatorLinksGroup> comparatorLinkGroups) {
+    public JenkinsReportJckGlobalConfig(String diffToolUrl, List<ComparatorLinksGroup> comparatorLinksGroups) {
         this.diffToolUrl = diffToolUrl;
-        this.comparatorLinkGroups = comparatorLinkGroups;
+        this.comparatorLinksGroups = comparatorLinksGroups;
     }
 
     public JenkinsReportJckGlobalConfig() {

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
@@ -7,6 +7,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.util.List;
 import java.util.logging.Logger;
 
 import hudson.Extension;
@@ -17,6 +18,7 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
     private static Logger logger = Logger.getLogger(JenkinsReportJckGlobalConfig.class.getName());
 
     String diffToolUrl;
+    List<ComparatorLinks> comparatorLinks;
 
     public static JenkinsReportJckGlobalConfig getInstance() {
         return GlobalConfiguration.all().get(JenkinsReportJckGlobalConfig.class);
@@ -47,9 +49,23 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
         this.diffToolUrl = diffToolUrl;
     }
 
+    public static List<ComparatorLinks> getGlobalComparatorLinks() {
+        return getInstance().getComparatorLinks();
+    }
+
+    public List<ComparatorLinks> getComparatorLinks() {
+        return comparatorLinks;
+    }
+
+    @DataBoundSetter
+    public void setComparatorLinks(List<ComparatorLinks> comparatorLinks) {
+        this.comparatorLinks = comparatorLinks;
+    }
+
     @DataBoundConstructor
-    public JenkinsReportJckGlobalConfig(String diffToolUrl) {
+    public JenkinsReportJckGlobalConfig(String diffToolUrl, List<ComparatorLinks> comparatorLinks) {
         this.diffToolUrl = diffToolUrl;
+        this.comparatorLinks = comparatorLinks;
     }
 
     public JenkinsReportJckGlobalConfig() {

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/LinkToComparator.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/LinkToComparator.java
@@ -1,0 +1,64 @@
+package io.jenkins.plugins.report.jtreg;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class LinkToComparator extends AbstractDescribableImpl<LinkToComparator> {
+    private String label;
+    private String spliterator;
+    private String comparatorArguments;
+    private String query;
+
+    @DataBoundConstructor
+    public LinkToComparator(String label, String spliterator, String comparatorArguments, String query) {
+        this.label = label;
+        this.spliterator = spliterator;
+        this.comparatorArguments = comparatorArguments;
+        this.query = query;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getSpliterator() {
+        return spliterator;
+    }
+
+    @DataBoundSetter
+    public void setSpliterator(String spliterator) {
+        this.spliterator = spliterator;
+    }
+
+    public String getComparatorArguments() {
+        return comparatorArguments;
+    }
+
+    @DataBoundSetter
+    public void setComparatorArguments(String comparatorArguments) {
+        this.comparatorArguments = comparatorArguments;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+    @DataBoundSetter
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<LinkToComparator> {
+        public String getDisplayName() {
+            return "Link to comparator tool";
+        }
+    }
+}

--- a/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/LinkToComparator.java
+++ b/report-jtreg-plugin/src/main/java/io/jenkins/plugins/report/jtreg/LinkToComparator.java
@@ -10,14 +10,12 @@ public class LinkToComparator extends AbstractDescribableImpl<LinkToComparator> 
     private String label;
     private String spliterator;
     private String comparatorArguments;
-    private String query;
 
     @DataBoundConstructor
-    public LinkToComparator(String label, String spliterator, String comparatorArguments, String query) {
+    public LinkToComparator(String label, String spliterator, String comparatorArguments) {
         this.label = label;
         this.spliterator = spliterator;
         this.comparatorArguments = comparatorArguments;
-        this.query = query;
     }
 
     public String getLabel() {
@@ -45,14 +43,6 @@ public class LinkToComparator extends AbstractDescribableImpl<LinkToComparator> 
     @DataBoundSetter
     public void setComparatorArguments(String comparatorArguments) {
         this.comparatorArguments = comparatorArguments;
-    }
-
-    public String getQuery() {
-        return query;
-    }
-    @DataBoundSetter
-    public void setQuery(String query) {
-        this.query = query;
     }
 
     @Extension

--- a/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
+++ b/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
@@ -36,7 +36,7 @@
                          <b>
                              <j:choose>
                                  <j:when test="${it.isDiffTool()}">
-                                     <j:forEach var="comparatorLinks" items="${it.matchedComparatorLinks}">
+                                     <j:forEach var="comparatorLinks" items="${it.getMatchedComparatorLinks()}">
                                          <div>
                                              <j:forEach var="link" items="${comparatorLinks.getLinks()}">
                                                  <a href="${it.createComparatorLinkUrl(link)}">${link.label}</a>&amp;nbsp;

--- a/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
+++ b/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
@@ -36,9 +36,9 @@
                          <b>
                              <j:choose>
                                  <j:when test="${it.isDiffTool()}">
-                                     <j:forEach var="comparatorLinks" items="${it.getMatchedComparatorLinks()}">
+                                     <j:forEach var="comparatorLinkGroups" items="${it.getMatchedComparatorLinksGroups()}">
                                          <div>
-                                             <j:forEach var="link" items="${comparatorLinks.getLinks()}">
+                                             <j:forEach var="link" items="${comparatorLinkGroups.getLinks()}">
                                                  <a href="${it.createComparatorLinkUrl(link)}">${link.label}</a>&amp;nbsp;
                                              </j:forEach>
                                          </div>

--- a/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
+++ b/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
@@ -39,7 +39,7 @@
                                      <j:forEach var="comparatorLinkGroups" items="${it.getMatchedComparatorLinksGroups()}">
                                          <div>
                                              <j:forEach var="link" items="${comparatorLinkGroups.getLinks()}">
-                                                 <a href="${it.createComparatorLinkUrl(link)}">${link.label}</a>&amp;nbsp;
+                                                 <a href="${it.createComparatorLinkUrl(it.getCompUrlStub(), link)}">${link.label}</a>&amp;nbsp;
                                              </j:forEach>
                                          </div>
                                      </j:forEach>

--- a/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
+++ b/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
@@ -36,10 +36,13 @@
                          <b>
                              <j:choose>
                                  <j:when test="${it.isDiffTool()}">
-                                     <a href="${it.linkTraces}">all traces</a>&amp;nbsp;
-                                     <a href="${it.compareArches}">compare architectures</a>&amp;nbsp;
-                                     <a href="${it.compareOsses}">comapre OSes</a>&amp;nbsp;
-                                     <a href="${it.compareVariants}">comapre variants</a>&amp;nbsp;
+                                     <j:forEach var="comparatorLinks" items="${it.matchedComparatorLinks}">
+                                         <div>
+                                             <j:forEach var="link" items="${comparatorLinks.getLinks()}">
+                                                 <a href="${it.createComparatorLinkUrl(link)}">${link.label}</a>&amp;nbsp;
+                                             </j:forEach>
+                                         </div>
+                                     </j:forEach>
                                  </j:when>
                                  <j:otherwise>
                                      diff tool is not configured. Set up url in jenkins main config

--- a/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -6,7 +6,7 @@
         </f:entry>
     </f:section>
     <f:section title="Comparator links">
-        <f:repeatable field="comparatorLinks">
+        <f:repeatable field="comparatorLinkGroups">
             <f:entry field="jobMatchRegex" title="Regex for matching jobs">
                 <f:textbox />
             </f:entry>

--- a/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -5,4 +5,27 @@
             <f:textbox/>
         </f:entry>
     </f:section>
+    <f:section title="Comparator links">
+        <f:repeatable field="comparatorLinks">
+            <f:entry field="jobMatchRegex" title="Regex for matching jobs">
+                <f:textbox />
+            </f:entry>
+            <f:repeatable field="links">
+                <f:entry field="label" title="Link label">
+                    <f:textbox />
+                </f:entry>
+                <f:entry field="spliterator" title="Regex to split the job names by">
+                    <f:textbox />
+                </f:entry>
+                <f:entry field="comparatorArguments" title="Comparator tool arguments (one on each line)">
+                    <f:textarea />
+                </f:entry>
+                <f:entry field="query" title="Regex query">
+                    <f:textbox />
+                </f:entry>
+                <f:repeatableDeleteButton/>
+            </f:repeatable>
+            <f:repeatableDeleteButton/>
+        </f:repeatable>
+    </f:section>
 </j:jelly>

--- a/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg-plugin/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -6,7 +6,7 @@
         </f:entry>
     </f:section>
     <f:section title="Comparator links">
-        <f:repeatable field="comparatorLinkGroups">
+        <f:repeatable field="comparatorLinksGroups">
             <f:entry field="jobMatchRegex" title="Regex for matching jobs">
                 <f:textbox />
             </f:entry>
@@ -19,9 +19,6 @@
                 </f:entry>
                 <f:entry field="comparatorArguments" title="Comparator tool arguments (one on each line)">
                     <f:textarea />
-                </f:entry>
-                <f:entry field="query" title="Regex query">
-                    <f:textbox />
                 </f:entry>
                 <f:repeatableDeleteButton/>
             </f:repeatable>

--- a/report-jtreg-plugin/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
+++ b/report-jtreg-plugin/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
@@ -1,0 +1,61 @@
+package io.jenkins.plugins.report.jtreg;
+
+import io.jenkins.plugins.report.jtreg.model.Suite;
+import io.jenkins.plugins.report.jtreg.model.SuiteTestChanges;
+import io.jenkins.plugins.report.jtreg.model.SuiteTestsWithResults;
+import io.jenkins.plugins.report.jtreg.model.SuitesWithResults;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+
+public class BuildReportExtendedPluginTest {
+    @org.junit.Test
+    public void getMatchedComparatorLinksGroupsTest() {
+        BuildReportExtendedPlugin bre = new BuildReportExtendedPlugin(
+                0,
+                "",
+                0,
+                0,
+                0,
+                new ArrayList<Suite>(),
+                new ArrayList<String>(),
+                new ArrayList<String>(),
+                new ArrayList<SuiteTestChanges>(),
+                0,
+                0,
+                new SuitesWithResults(new ArrayList<SuiteTestsWithResults>()),
+                "tck-jp17-ojdk17~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.beaker-x11.defaultgc.fips.lnxagent.jfroff"
+        );
+
+        // arguments without any wildcard
+        LinkToComparator ltc = new LinkToComparator("", "[.-]", "--arguments\n--without\n--any\n--wildcard");
+        String output = bre.createComparatorLinkUrl("", ltc);
+        Assert.assertEquals("--arguments+--without+--any+--wildcard+", output);
+
+        // arguments with valid wildcards
+        ltc = new LinkToComparator("", "[.-]", "--something-%{1}-something\n--%{N-2}\n--%{SPLIT}");
+        output = bre.createComparatorLinkUrl("", ltc);
+        Assert.assertEquals("--something-tck-something+--lnxagent+--%5B.-%5D+", output);
+
+        // arguments with invalid wildcards (out of range of the job name)
+        ltc = new LinkToComparator("", "[.-]", "--%{20}");
+        output = bre.createComparatorLinkUrl("", ltc);
+        Assert.assertEquals("The+number+given+is+out+of+range+of+the+job+name%21+", output);
+
+        ltc = new LinkToComparator("", "[.-]", "--%{-1}");
+        output = bre.createComparatorLinkUrl("", ltc);
+        Assert.assertEquals("The+number+given+is+out+of+range+of+the+job+name%21+", output);
+
+        ltc = new LinkToComparator("", "[.-]", "--%{N-20}");
+        output = bre.createComparatorLinkUrl("", ltc);
+        Assert.assertEquals("The+number+given+is+out+of+range+of+the+job+name%21+", output);
+
+        ltc = new LinkToComparator("", "[.-]", "--%{N}");
+        output = bre.createComparatorLinkUrl("", ltc);
+        Assert.assertEquals("The+number+given+is+out+of+range+of+the+job+name%21+", output);
+
+        ltc = new LinkToComparator("", "[.-]", "--%{N+5}");
+        output = bre.createComparatorLinkUrl("", ltc);
+        Assert.assertEquals("The+number+given+is+out+of+range+of+the+job+name%21+", output);
+    }
+}


### PR DESCRIPTION
## Comparator Jenkins intergration
Added a `Comparator links` section into the Jenkins global config in which you can match a job by regex and then add multiple links to Comparator tool. Each link has a label, spliterator (a regex used to split the job name into multiple "elements") and a field to enter comparator arguments. 

When you enter a `--regex` argument, the given value is taken and evaluated, there are some "wildcards" you can use in this query:
- `%{X}` (you can use any number in place of X) - this evaluates to the Xth element of the split job name
- `%{N-X}` (you can use any number in place of X) - this evaluates to the Xth LAST element of the split job name
- `%{S}` or `%{SPLIT}` - this evaluates to the spliterator expression

The links are added to the java-reports page