### PR TITLE
Changes to Comparator arguments

### DIFF
--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/HelpMessage.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/HelpMessage.java
@@ -52,6 +52,10 @@ final public class HelpMessage {
             "                  " + ArgumentsDeclaration.forceArg.getHelp() + "\n" +
             "    " + ArgumentsDeclaration.formattingArg.getName() + ArgumentsDeclaration.formattingArg.getUsage() + "\n" +
             "                  " + ArgumentsDeclaration.formattingArg.getHelp() + "\n" +
+            "    " + ArgumentsDeclaration.exactTestsArg.getName() + ArgumentsDeclaration.exactTestsArg.getUsage() + "\n" +
+            "                  " + ArgumentsDeclaration.exactTestsArg.getHelp() + "\n" +
+            "    " + ArgumentsDeclaration.useDefaultBuildArg.getName() + ArgumentsDeclaration.useDefaultBuildArg.getUsage() + "\n" +
+            "                  " + ArgumentsDeclaration.useDefaultBuildArg.getHelp() + "\n" +
             "\n" +
             "Query string syntax:\n" +
             JobsByQuery.queryStringUsage +

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsDeclaration.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsDeclaration.java
@@ -11,10 +11,10 @@ public final class ArgumentsDeclaration {
     public static final Argument pathArg = new Argument("--path", "A system path to a directory with your jenkins jobs. This argument is mandatory", " <path/to/jenkins/jobs>");
     public static final Argument nvrArg = new Argument("--nvr", "To specify what builds to take (only builds with specified NVRs). The syntax is described below.", " <nvrquery>");
     public static final Argument historyArg = new Argument("--history", "To specify the maximum number of builds to look in.", " <number>");
-    public static final Argument skipFailedArg = new Argument("--skip-failed", "Specify whether the comparator should skip failed tests (only take successful and unstable) or take all. The default value is true.", "=<true/false>");
+    public static final Argument skipFailedArg = new Argument("--skip-failed", "Specify whether the comparator should skip failed tests (only take successful and unstable) or take all. The default value is true.", " <true/false>");
     public static final Argument forceArg = new Argument("--force", "Used for forcing vague requests, that could potentially take a long time.", "");
-    public static final Argument onlyVolatileArg = new Argument("--only-volatile", "Specify true to show only non stable tests with the arguments list and compare (shows only tests, that are NOT failed everywhere). The default value is false.", "=<true/false>");
+    public static final Argument onlyVolatileArg = new Argument("--only-volatile", "Specify true to show only non stable tests with the arguments list and compare (shows only tests, that are NOT failed everywhere). The default value is false.", " <true/false>");
     public static final Argument exactTestsArg = new Argument("--exact-tests", "Specify (with regex) the exact tests to show only. The rest of tests will be ignored.", " <regex>");
-    public static final Argument formattingArg = new Argument("--formatting", "Specify the output formatting (plain, color or html). The default is plain.", "=<plain/color/html>");
-    public static final Argument useDefaultBuildArg = new Argument("--use-default-build", "If set to true and no matching build with given NVR was found, the tool will use the latest (default) build instead. Default value is false.", "=<true/false>");
+    public static final Argument formattingArg = new Argument("--formatting", "Specify the output formatting (plain, color or html). The default is plain.", " <plain/color/html>");
+    public static final Argument useDefaultBuildArg = new Argument("--use-default-build", "If set to true and no matching build with given NVR was found, the tool will use the latest (default) build instead. Default value is false.", " <true/false>");
 }


### PR DESCRIPTION
## Changes to Comparator arguments
The arguments and their values are now consistent - they only take SPACE between the argument and its value
E.g. `--formatting color` (NOT `--formatting=color`)

I also added two arguments to the help message that were not there before (`--exact-tests` and `--use-default-build`).