### PR TITLE
Getting the NVR from build.xml

### DIFF
--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/Builds.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/Builds.java
@@ -41,7 +41,7 @@ public class Builds {
         if (nvrQuery.equals("") || nvrQuery.equals("*")) {
             return true;
         }
-        String buildNvr = JobsRecognition.getChangelogsNvr(build);
+        String buildNvr = JobsRecognition.getBuildXmlNvr(build);
         if (buildNvr == null) {
             return false;
         } else if (nvrQuery.charAt(0) == '{') {
@@ -126,6 +126,6 @@ public class Builds {
     }
 
     public static String getNvr(File build) {
-        return JobsRecognition.getChangelogsNvr(build);
+        return JobsRecognition.getBuildXmlNvr(build);
     }
 }

--- a/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/BuildsTest.java
+++ b/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/BuildsTest.java
@@ -1,7 +1,5 @@
 package io.jenkins.plugins.report.jtreg.main.comparator;
 
-import io.jenkins.plugins.report.jtreg.main.diff.cmdline.JobsRecognition;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -10,38 +8,35 @@ import java.nio.file.Files;
 
 public class BuildsTest {
 
-    private static File changelogFile;
+    private static File buildFile;
 
     @org.junit.BeforeClass
     public static void createChangelogFile() throws IOException {
         File tmpdir = Files.createTempDirectory("reportJtregBuildTestDir").toFile();
-        changelogFile = JobsRecognition.creteChangelogFile(tmpdir);
+        buildFile = new File(tmpdir.getAbsolutePath() + "/build.xml");
         byte[] orig = BuildsTest.class.getResourceAsStream("/io/jenkins/plugins/report/jtreg/main/comparator/dummyNvr1.xml").readAllBytes();
-        Files.write(changelogFile.toPath(), orig);
+        Files.write(buildFile.toPath(), orig);
     }
 
     @org.junit.Test
     public void checkForNvrTest() {
         boolean b = Builds.checkForNvr(new File("unused in this call"), "*");
         org.junit.Assert.assertTrue(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "blah");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "blah");
         org.junit.Assert.assertFalse(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "{blah}");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "{blah}");
         org.junit.Assert.assertFalse(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "{blah, bleh}");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "{blah, bleh}");
         org.junit.Assert.assertFalse(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "java-17-openjdk-portable-17.0.6.0.10-6.el7openjdkportable");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "java-11-openjdk-11.0.20.0.8-3.el8");
         org.junit.Assert.assertTrue(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "{blah,java-17-openjdk-portable-17.0.6.0.10-6.el7openjdkportable, bleh}");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "{blah,java-11-openjdk-11.0.20.0.8-3.el8, bleh}");
         org.junit.Assert.assertTrue(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "java-17-openjdk-portable-17.0.6.0.10-6");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "java-11-openjdk-11.0.20.0.8-3");
         org.junit.Assert.assertFalse(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "java-17-openjdk-portable-17.0.6.0.10-6.*");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "java-11-openjdk-11.0.20.0.8-3.*");
         org.junit.Assert.assertTrue(b);
-        b = Builds.checkForNvr(changelogFile.getParentFile(), "{blah,java-17-openjdk-portable-17.0.6.0.10-6.*, bleh}");
+        b = Builds.checkForNvr(buildFile.getParentFile(), "{blah,java-11-openjdk-11.0.20.0.8-3.*, bleh}");
         org.junit.Assert.assertTrue(b);
-
-
-
     }
 }

--- a/report-jtreg-comparator/src/test/resources/io/jenkins/plugins/report/jtreg/main/comparator/dummyNvr1.xml
+++ b/report-jtreg-comparator/src/test/resources/io/jenkins/plugins/report/jtreg/main/comparator/dummyNvr1.xml
@@ -1,111 +1,114 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version='1.1' encoding='UTF-8'?>
 <build>
-    <id>2387059</id>
-    <name>java-17-openjdk-portable</name>
-    <version>17.0.6.0.10</version>
-    <release>6.el7openjdkportable</release>
-    <nvr>java-17-openjdk-portable-17.0.6.0.10-6.el7openjdkportable</nvr>
-    <completion>2023-02-22 07:51:22.780374</completion>
-    <rpms>
-        <rpm>
-            <name>java-17-openjdk-portable-devel</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-devel-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-            <url>http://download.eng.brq.redhat.com/brewroot/packages/java-17-openjdk-portable/17.0.6.0.10/6.el7openjdkportable/x86_64/java-17-openjdk-portable-devel-17.0.6.0.10-6.el7openjdkportable.x86_64.rpm</url>
-            <hashSum>0ceb745e24cf97b54e4da71b1adb0c42</hashSum>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-misc</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-misc-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-            <url>http://download.eng.brq.redhat.com/brewroot/packages/java-17-openjdk-portable/17.0.6.0.10/6.el7openjdkportable/x86_64/java-17-openjdk-portable-misc-17.0.6.0.10-6.el7openjdkportable.x86_64.rpm</url>
-            <hashSum>d4934a8e796bc8370bafe797ddc3fa84</hashSum>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-unstripped</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-unstripped-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-            <url>http://download.eng.brq.redhat.com/brewroot/packages/java-17-openjdk-portable/17.0.6.0.10/6.el7openjdkportable/x86_64/java-17-openjdk-portable-unstripped-17.0.6.0.10-6.el7openjdkportable.x86_64.rpm</url>
-            <hashSum>55077a3a7adf7c02e824b4cde7ae31ec</hashSum>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-docs</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-docs-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-            <url>http://download.eng.brq.redhat.com/brewroot/packages/java-17-openjdk-portable/17.0.6.0.10/6.el7openjdkportable/x86_64/java-17-openjdk-portable-docs-17.0.6.0.10-6.el7openjdkportable.x86_64.rpm</url>
-            <hashSum>bb4870f05cdf8be4be35a4afa0ed21d4</hashSum>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-fastdebug</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-fastdebug-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-devel-slowdebug</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-devel-slowdebug-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-static-libs-fastdebug</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-static-libs-fastdebug-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-static-libs-slowdebug</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-static-libs-slowdebug-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-slowdebug</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-slowdebug-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-devel-fastdebug</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-devel-fastdebug-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-        <rpm>
-            <name>java-17-openjdk-portable-static-libs</name>
-            <version>17.0.6.0.10</version>
-            <release>6.el7openjdkportable</release>
-            <nvr>java-17-openjdk-portable-static-libs-17.0.6.0.10-6.el7openjdkportable</nvr>
-            <arch>x86_64</arch>
-        </rpm>
-    </rpms>
-    <tags>
-        <tag>openjdk-portable-rhel-7-candidate</tag>
-    </tags>
-    <provider>
-        <topUrl>https://brewhub.engineering.redhat.com/brewhub</topUrl>
-        <downloadUrl>http://download.eng.brq.redhat.com/brewroot/packages/</downloadUrl>
-    </provider>
-    <srcUrl>http://download.eng.brq.redhat.com/brewroot/packages/java-17-openjdk-portable/17.0.6.0.10/6.el7openjdkportable/src/java-17-openjdk-portable-17.0.6.0.10-6.el7openjdkportable.src.rpm</srcUrl>
+    <actions>
+        <hudson.model.CauseAction>
+            <causeBag class="linked-hash-map">
+                <entry>
+                    <hudson.triggers.SCMTrigger_-SCMTriggerCause/>
+                    <int>16</int>
+                </entry>
+            </causeBag>
+        </hudson.model.CauseAction>
+        <hudson.triggers.SCMTrigger_-BuildAction/>
+        <jenkins.scm.cvs.QuietPeriodCompleted plugin="cvs@2.19.1">
+            <timestamp>1689965050403</timestamp>
+        </jenkins.scm.cvs.QuietPeriodCompleted>
+        <hudson.plugins.scm.koji.KojiEnvVarsAction plugin="jenkins-scm-koji-plugin@2.0-SNAPSHOT">
+            <nvr>java-11-openjdk-11.0.20.0.8-3.el8</nvr>
+            <rpmsDir>/home/tester/workspace/workspace/crypto~tests-jp11-ojdk11~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.vagrant-x11.defaultgc.legacy.lnxagent.jfroff/rpms</rpmsDir>
+            <rpmFiles>/home/tester/workspace/workspace/crypto~tests-jp11-ojdk11~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.vagrant-x11.defaultgc.legacy.lnxagent.jfroff/rpms/java-11-openjdk-fastdebug-11.0.20.0.8-3.el8.aarch64.rpm:/home/tester/workspace/workspace/crypto~tests-jp11-ojdk11~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.vagrant-x11.defaultgc.legacy.lnxagent.jfroff/rpms/java-11-openjdk-headless-fastdebug-11.0.20.0.8-3.el8.aarch64.rpm:/home/tester/workspace/workspace/crypto~tests-jp11-ojdk11~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.vagrant-x11.defaultgc.legacy.lnxagent.jfroff/rpms/java-11-openjdk-devel-fastdebug-11.0.20.0.8-3.el8.aarch64.rpm:/home/tester/workspace/workspace/crypto~tests-jp11-ojdk11~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.vagrant-x11.defaultgc.legacy.lnxagent.jfroff/rpms/java-11-openjdk-jmods-fastdebug-11.0.20.0.8-3.el8.aarch64.rpm:/home/tester/workspace/workspace/crypto~tests-jp11-ojdk11~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.vagrant-x11.defaultgc.legacy.lnxagent.jfroff/rpms/java-11-openjdk-src-fastdebug-11.0.20.0.8-3.el8.aarch64.rpm</rpmFiles>
+        </hudson.plugins.scm.koji.KojiEnvVarsAction>
+        <hudson.plugins.scm.koji.KojiRevisionState plugin="jenkins-scm-koji-plugin@2.0-SNAPSHOT">
+            <build>
+                <id>2605086</id>
+                <name>java-11-openjdk</name>
+                <version>11.0.20.0.8</version>
+                <release>3.el8</release>
+                <nvr>java-11-openjdk-11.0.20.0.8-3.el8</nvr>
+                <completionTime>2023-07-20 20:21:15.380596</completionTime>
+                <rpms>
+                    <hudson.plugins.scm.koji.model.RPM>
+                        <name>java-11-openjdk</name>
+                        <version>11.0.20.0.8</version>
+                        <release>3.el8</release>
+                        <nvr>java-11-openjdk-11.0.20.0.8-3.el8</nvr>
+                        <arch>aarch64</arch>
+                    </hudson.plugins.scm.koji.model.RPM>
+                    <hudson.plugins.scm.koji.model.RPM>
+                        <name>java-11-openjdk-slowdebug</name>
+                        <version>11.0.20.0.8</version>
+                        <release>3.el8</release>
+                        <nvr>java-11-openjdk-slowdebug-11.0.20.0.8-3.el8</nvr>
+                        <arch>aarch64</arch>
+                    </hudson.plugins.scm.koji.model.RPM>
+                    <hudson.plugins.scm.koji.model.RPM>
+                        <name>java-11-openjdk-fastdebug</name>
+                        <version>11.0.20.0.8</version>
+                        <release>3.el8</release>
+                        <nvr>java-11-openjdk-fastdebug-11.0.20.0.8-3.el8</nvr>
+                        <arch>aarch64</arch>
+                    </hudson.plugins.scm.koji.model.RPM>
+                    <hudson.plugins.scm.koji.model.RPM>
+                        <name>java-11-openjdk-headless</name>
+                        <version>11.0.20.0.8</version>
+                        <release>3.el8</release>
+                        <nvr>java-11-openjdk-headless-11.0.20.0.8-3.el8</nvr>
+                        <arch>aarch64</arch>
+                    </hudson.plugins.scm.koji.model.RPM>
+                    <hudson.plugins.scm.koji.model.RPM>
+                        <name>java-11-openjdk-headless-slowdebug</name>
+                        <version>11.0.20.0.8</version>
+                        <release>3.el8</release>
+                        <nvr>java-11-openjdk-headless-slowdebug-11.0.20.0.8-3.el8</nvr>
+                        <arch>aarch64</arch>
+                    </hudson.plugins.scm.koji.model.RPM>
+                </rpms>
+                <tags>
+                    <string>rhel-8.9.0-candidate</string>
+                    <string>RHBA-2023:117615-pending</string>
+                    <string>java-openjdk-rhel-8-build</string>
+                    <string>rhel-8.8.0-z-pending</string>
+                    <string>rhel-8.8.0-z-candidate</string>
+                    <string>rhel-8.8.0-z-pending-signed</string>
+                </tags>
+            </build>
+        </hudson.plugins.scm.koji.KojiRevisionState>
+        <io.jenkins.plugins.report.genericdiff.DiffReportAction plugin="report-diff@3.0">
+            <build class="build" reference="../../.."/>
+        </io.jenkins.plugins.report.genericdiff.DiffReportAction>
+        <io.jenkins.plugins.report.genericdiff.RpmsReportAction plugin="report-diff@3.0">
+            <build class="build" reference="../../.."/>
+        </io.jenkins.plugins.report.genericdiff.RpmsReportAction>
+        <io.jenkins.plugins.report.jtreg.ReportAction plugin="report-jtreg@2.0-SNAPSHOT">
+            <build class="build" reference="../../.."/>
+            <prefixes>
+                <string>jtreg</string>
+            </prefixes>
+        </io.jenkins.plugins.report.jtreg.ReportAction>
+        <com.redhat.jenkins.plugins.ci.polarion.CIPolarionXUnitImporterBuildAction plugin="redhat-ci-plugin@1.5.11">
+            <providerData>
+                <name>Red Hat UMB</name>
+                <checks/>
+                <timeout>60</timeout>
+            </providerData>
+            <hasXUnitFiles>false</hasXUnitFiles>
+        </com.redhat.jenkins.plugins.ci.polarion.CIPolarionXUnitImporterBuildAction>
+    </actions>
+    <queueId>1233201</queueId>
+    <timestamp>1690019562385</timestamp>
+    <startTime>1690019563007</startTime>
+    <result>SUCCESS</result>
+    <displayName>11.0.20.0.8-3.el8</displayName>
+    <duration>2338145</duration>
+    <charset>UTF-8</charset>
+    <keepLog>false</keepLog>
+    <builtOn>norn3.brq.redhat.com</builtOn>
+    <workspace>/home/tester/workspace/workspace/crypto~tests-jp11-ojdk11~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.vagrant-x11.defaultgc.legacy.lnxagent.jfroff</workspace>
+    <hudsonVersion>2.401.1</hudsonVersion>
+    <scm class="hudson.plugins.scm.koji.KojiChangeLogParser" plugin="jenkins-scm-koji-plugin@2.0-SNAPSHOT"/>
+    <culprits class="java.util.Collections$UnmodifiableSet">
+        <c class="sorted-set">
+            <string>SYSTEM</string>
+        </c>
+    </culprits>
 </build>

--- a/report-jtreg-diff/src/main/java/io/jenkins/plugins/report/jtreg/main/diff/CompareBuilds.java
+++ b/report-jtreg-diff/src/main/java/io/jenkins/plugins/report/jtreg/main/diff/CompareBuilds.java
@@ -256,12 +256,12 @@ public class CompareBuilds {
         }
         format().reset();
         format().println();
-        String nwNra = JobsRecognition.getChangelogsNvr(new File(br.getBuildName()));
+        String nwNra = JobsRecognition.getBuildXmlNvr(new File(br.getBuildName()));
         format().startTitle1();
         format().print(nwNra);
         String nwNraOld = null;
         if (old != null) {
-            nwNraOld = JobsRecognition.getChangelogsNvr(new File(old.getBuildName()));
+            nwNraOld = JobsRecognition.getBuildXmlNvr(new File(old.getBuildName()));
             format().print(" x(old) " + nwNraOld);
         }
         if (nwNra != null || nwNraOld != null) {
@@ -505,7 +505,7 @@ public class CompareBuilds {
         format().println("  ***  All tests!  *** ");
         format().reset();
         format().startTitle3();
-        String nwNra = JobsRecognition.getChangelogsNvr(new File(bre.getBuildName()));
+        String nwNra = JobsRecognition.getBuildXmlNvr(new File(bre.getBuildName()));
         format().print(nwNra + " (" + bre.getBuildNumber() + ": " + bre.getBuildName() + ")");
         format().reset();
         List<SuiteTestsWithResults> all = bre.getAllTests().getAllTestsAndSuites();


### PR DESCRIPTION
Changed the `getChangelogsNvr()` method to `getBuildXmlNvr()`, which takes the NVR from each build's `build.xml` file instead of the `changelog.xml` file like before.