### PR TITLE
Support xz compressed results

### DIFF
--- a/report-jtreg-lib/pom.xml
+++ b/report-jtreg-lib/pom.xml
@@ -19,5 +19,10 @@
             <artifactId>gson</artifactId>
             <version>2.10.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.tukaani</groupId>
+            <artifactId>xz</artifactId>
+            <version>1.9</version>
+        </dependency>
     </dependencies>
 </project>

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/parsers/JckReportParser.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/parsers/JckReportParser.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.report.jtreg.parsers;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.plugins.report.jtreg.model.*;
+import org.tukaani.xz.XZInputStream;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -42,12 +43,18 @@ public class JckReportParser implements ReportParser {
         if (path.toString().endsWith(".gz")) {
             return new GZIPInputStream(stream);
         }
+        if (path.toString().endsWith(".xz")) {
+            return new org.tukaani.xz.XZInputStream(stream);
+        }
         return stream;
     }
 
     @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "We desrve to die")
     private String suiteName(Path path) {
         String fullName = path.getFileName().toString();
+        if (fullName.endsWith(".xml.xz")) {
+            return fullName.substring(0, fullName.length() - 7);
+        }
         if (fullName.endsWith(".xml.gz")) {
             return fullName.substring(0, fullName.length() - 7);
         }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/parsers/JtregReportParser.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/parsers/JtregReportParser.java
@@ -51,6 +51,7 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorInputStream;
 import org.apache.commons.io.input.CloseShieldInputStream;
+import org.tukaani.xz.XZInputStream;
 
 import static javax.xml.stream.XMLStreamConstants.CDATA;
 import static javax.xml.stream.XMLStreamConstants.CHARACTERS;
@@ -214,7 +215,7 @@ public class  JtregReportParser implements ReportParser {
         map.put(".tar", in -> new TarArchiveInputStream(in));
         map.put(".tar.gz", in -> new TarArchiveInputStream(new GzipCompressorInputStream(in)));
         map.put(".tar.bz2", in -> new TarArchiveInputStream(new BZip2CompressorInputStream(in)));
-        map.put(".tar.xz", in -> new TarArchiveInputStream(new XZCompressorInputStream(in)));
+        map.put(".tar.xz", in -> new TarArchiveInputStream(new org.tukaani.xz.XZInputStream(in)));
 
         return Collections.unmodifiableMap(map);
     }

--- a/report-jtreg/pom.xml
+++ b/report-jtreg/pom.xml
@@ -29,6 +29,11 @@
             <version>5.4.0</version>
         </dependency>
         <dependency>
+          <groupId>org.tukaani</groupId>
+          <artifactId>xz</artifactId>
+          <version>1.9</version>
+        </dependency>
+        <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>report-jtreg-lib</artifactId>
             <version>${revision}${changelist}</version>

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/JtregReportParserTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/JtregReportParserTest.java
@@ -3,13 +3,20 @@ package io.jenkins.plugins.report.jtreg;
 import io.jenkins.plugins.report.jtreg.model.Test;
 import io.jenkins.plugins.report.jtreg.model.TestOutput;
 import org.junit.Assert;
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.XZOutputStream;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 
 import io.jenkins.plugins.report.jtreg.model.Suite;
@@ -19,11 +26,15 @@ public class JtregReportParserTest {
 
     private final static String rhqeFileName = "rhqe.tar.gz";
 
-    @org.junit.Test
-    public void parseRhqeTest() throws IOException {
-        String tarball = "src/test/resources/" + rhqeFileName; //jtreg arser currently depends on file, and that file have to be tarball with named xmls
-        final JtregReportParser parser = new JtregReportParser();
-        Suite actualReport = parser.parsePath(new File(tarball).toPath());
+    private void copyStream(InputStream is, OutputStream os) throws IOException {
+        int b;
+        while ((b = is.read()) >= 0) {
+            os.write(b);
+        }
+        is.close();
+    }
+
+    private void checkReport(Suite actualReport) throws IOException {
         List<Test> failures = actualReport.getReport().getTestProblems();
         Assert.assertEquals(2, failures.size());
         List<TestOutput> outputs1 = failures.get(0).getOutputs();
@@ -49,6 +60,33 @@ public class JtregReportParserTest {
         Assert.assertTrue(s.contains("Pack"));
         Assert.assertTrue(s.contains("head"));
         Assert.assertTrue(s.contains("Attempt"));
+    }
+
+    @org.junit.Test
+    public void parseRhqeTestGz() throws IOException {
+        String tarball = "src/test/resources/" + rhqeFileName; //jtreg arser currently depends on file, and that file have to be tarball with named xmls
+        final JtregReportParser parser = new JtregReportParser();
+        Suite actualReport = parser.parsePath(new File(tarball).toPath());
+        checkReport(actualReport);
+    }
+
+    @org.junit.Test
+    public void parseRhqeTestXz() throws IOException {
+        // repack as .tar.xz and test
+        Path path = Files.createTempFile("rhqe", ".tar.xz");
+        try (InputStream is = this.getClass().getResourceAsStream("/" + rhqeFileName);
+            GZIPInputStream gis = new GZIPInputStream(is);
+            FileOutputStream fos = new FileOutputStream(path.toFile());
+            OutputStream xzos = new XZOutputStream(fos, new LZMA2Options())) {
+            copyStream(gis, xzos);
+            xzos.close();
+            final JtregReportParser parser = new JtregReportParser();
+            Suite actualReport = parser.parsePath(path);
+            Assert.assertNotNull("Suite in not null", actualReport);
+            checkReport(actualReport);
+        } finally {
+            Files.delete(path);
+        }
     }
 
 }


### PR DESCRIPTION
This adds support for `xz` compressed results of jtregs and tcks. Tested on artifacts from jtreg and jdk jobs repacked with xz compression in local jenkins instance. Worked for me.

Notes:
`JtregReportParser.java` already had code for .tar.xz, using  `XZCompressorInputStream`  from `commons-compress`. However it fails for .tar.xz with ClassNotFoundException (org.tukaani.xz.XZInputStream). commons-compress has optional dependency on org.tukaani.xz, which is [used](https://github.com/apache/commons-compress/blob/b8ce4932b937fdf27e72919be937f3c8942bd8d8/src/main/java/org/apache/commons/compress/compressors/xz/XZCompressorInputStream.java#L31) in XZCompressorInputStream. This did not work for me even when org.tukaani xz dependency was added, so I switched directly to `XZInputStream` from `org.tukaani.xz`, which did work.