### PR TITLE
Added dynamic macros into Jenkins config

### DIFF
--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/HelpMessage.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/HelpMessage.java
@@ -63,7 +63,7 @@ final public class HelpMessage {
             "        Another type of arguments you can use are dynamic arguments. They are used\n" +
             "        for further filtering the jobs/builds to compare by any value in their config\n" +
             "        files.\n" +
-            "        First, you must define the value to look for in a config file. The general syntax is:\n" +
+            "        You must define the value to look for in a config file. The general syntax is:\n" +
             "          --X \"configFileName:whatAreYouLookingFor:queryToFindIt\"\n" +
             "            Instead of --X, you use one of these arguments:\n" +
             "    " + ArgumentsDeclaration.buildConfigFindArg.getName() + ArgumentsDeclaration.buildConfigFindArg.getUsage() + "\n" +
@@ -76,8 +76,8 @@ final public class HelpMessage {
             "            queryToFindIt is the query, to find the value in the config file. Currently,\n" +
             "                XPath is supported for XML files, Json Query for JSON files and plain value\n" +
             "                for properties files.\n" +
-            "        After defining the value, you can proceed to the filtering itself. For that, you\n" +
-            "        use the whatAreYouLooking part from the definition as an argument and this syntax:\n" +
+            "        Now, you can proceed to the filtering itself. For that, you use the whatAreYouLooking\n" +
+            "        part from the definition as an argument and this syntax:\n" +
             "            It either takes RegEx to match the value with or multiple RegExes\n" +
             "            in curly brackets, separated by commas. (e.g. {nvr1.*,nvr2.*})\n" +
             "        Example:\n" +

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsParsing.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsParsing.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.report.jtreg.main.comparator.arguments;
 
+import io.jenkins.plugins.report.jtreg.Constants;
 import io.jenkins.plugins.report.jtreg.main.comparator.HelpMessage;
 import io.jenkins.plugins.report.jtreg.main.comparator.Options;
 import io.jenkins.plugins.report.jtreg.main.comparator.jobs.DefaultProvider;
@@ -181,6 +182,11 @@ public class ArgumentsParsing {
         Options.Configuration configuration;
         // checks the number of items it got from the splitting of the value
         if (values.length == 3) { // filename:whatToFind:findQuery
+            // check if the user is trying to escape the current directory with ../
+            if (values[0].matches(Constants.ESCAPE_DIRECTORY_REGEX)) {
+                throw new RuntimeException("Cannot escape from the directory with config file to its parent directory.");
+            }
+
             if (currentArg.equals(ArgumentsDeclaration.buildConfigFindArg.getName())) {
                 configuration = new Options.Configuration(values[0], values[2], Options.Locations.Build);
             } else {

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsParsing.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsParsing.java
@@ -9,152 +9,162 @@ import io.jenkins.plugins.report.jtreg.main.comparator.jobs.JobsByRegex;
 import io.jenkins.plugins.report.jtreg.formatters.ColorFormatter;
 import io.jenkins.plugins.report.jtreg.formatters.HtmlFormatter;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ArgumentsParsing {
     // parses the given arguments and returns instance of Options
     public static Options parse(String[] arguments) {
         Options options = new Options();
 
-        if (arguments.length >= 1) {
-            List<String> dynamicArgs = new ArrayList<>(); // a list for dynamic arguments
+        Map<String, String> otherArgs = new HashMap<>(); // a list for unmatched (for now) arguments
 
-            for (int i = 0; i < arguments.length; i++) {
-                // delete all leading - characters
-                String currentArg = arguments[i].replaceAll("^-+", "--");
+        if (arguments.length == 0) {
+            throw new RuntimeException("Expected some arguments.");
+        }
 
-                if (!currentArg.matches("^--.*")) {
-                    throw new RuntimeException("Unknown argument " + arguments[i] + ", did you forget the leading hyphens (--)?");
+        for (int i = 0; i < arguments.length; i++) {
+            // delete all leading - characters
+            String currentArg = arguments[i].replaceAll("^-+", "--");
+
+            if (!currentArg.matches("^--.*")) {
+                throw new RuntimeException("Unknown argument " + arguments[i] + ", did you forget the leading hyphens (--)?");
+            }
+
+            // parsing the arguments:
+            if (currentArg.equals(ArgumentsDeclaration.helpArg.getName()) || currentArg.equals("--h")) {
+                // --help
+                System.out.print(HelpMessage.HELP_MESSAGE);
+                Options tmpO = new Options();
+                tmpO.setDie(true);
+                return tmpO;
+            } else if (currentArg.equals(ArgumentsDeclaration.listArg.getName())) {
+                // --list
+                if (options.getOperation() != null) {
+                    throw new RuntimeException("Cannot combine --list with other operations.");
+                }
+                options.setOperation(Options.Operations.List);
+
+            } else if (currentArg.equals(ArgumentsDeclaration.enumerateArg.getName())) {
+                // --enumerate
+                if (options.getOperation() != null) {
+                    throw new RuntimeException("Cannot combine --enumerate with other operations.");
+                }
+                options.setOperation(Options.Operations.Enumerate);
+
+            } else if (currentArg.equals(ArgumentsDeclaration.compareArg.getName())) {
+                // --compare
+                if (options.getOperation() != null) {
+                    throw new RuntimeException("Cannot combine --compare with other operations.");
+                }
+                options.setOperation(Options.Operations.Compare);
+
+            } else if (currentArg.equals(ArgumentsDeclaration.printArg.getName())) {
+                // --print
+                if (options.getOperation() != null) {
+                    throw new RuntimeException("Cannot combine --print with other operations.");
+                }
+                options.setOperation(Options.Operations.Print);
+
+            } else if (currentArg.equals(ArgumentsDeclaration.virtualArg.getName())) {
+                // --virtual
+                options.setPrintVirtual(true);
+
+            } else if (currentArg.equals(ArgumentsDeclaration.pathArg.getName())) {
+                // --path
+                options.setJobsPath(getArgumentValue(arguments, i++));
+
+            } else if (currentArg.equals(ArgumentsDeclaration.historyArg.getName())) {
+                // --history
+                options.setNumberOfBuilds(Integer.parseInt(getArgumentValue(arguments, i++)));
+
+            } else if (currentArg.equals(ArgumentsDeclaration.skipFailedArg.getName())) {
+                // --skip-failed
+                if (!Boolean.parseBoolean(getArgumentValue(arguments, i++))) {
+                    // if skip failed = false, any result value is taken, so .*
+                    options.getConfiguration("result").setValue(".*");
                 }
 
-                // parsing the arguments:
-                if (currentArg.equals(ArgumentsDeclaration.helpArg.getName()) || currentArg.equals("--h")) {
-                    // --help
-                    System.out.print(HelpMessage.HELP_MESSAGE);
-                    Options tmpO = new Options();
-                    tmpO.setDie(true);
-                    return tmpO;
-                } else if (currentArg.equals(ArgumentsDeclaration.listArg.getName())) {
-                    // --list
-                    if (options.getOperation() != null) {
-                        throw new RuntimeException("Cannot combine --list with other operations.");
-                    }
-                    options.setOperation(Options.Operations.List);
+            } else if (currentArg.equals(ArgumentsDeclaration.forceArg.getName())) {
+                // --force
+                options.setForceVague(true);
 
-                } else if (currentArg.equals(ArgumentsDeclaration.enumerateArg.getName())) {
-                    // --enumerate
-                    if (options.getOperation() != null) {
-                        throw new RuntimeException("Cannot combine --enumerate with other operations.");
-                    }
-                    options.setOperation(Options.Operations.Enumerate);
+            } else if (currentArg.equals(ArgumentsDeclaration.onlyVolatileArg.getName())) {
+                // --only-volatile
+                options.setOnlyVolatile(Boolean.parseBoolean(getArgumentValue(arguments, i++)));
 
-                } else if (currentArg.equals(ArgumentsDeclaration.compareArg.getName())) {
-                    // --compare
-                    if (options.getOperation() != null) {
-                        throw new RuntimeException("Cannot combine --compare with other operations.");
-                    }
-                    options.setOperation(Options.Operations.Compare);
+            } else if (currentArg.equals(ArgumentsDeclaration.exactTestsArg.getName())) {
+                // --exact-tests
+                options.setExactTestsRegex(getArgumentValue(arguments, i++));
 
-                } else if (currentArg.equals(ArgumentsDeclaration.printArg.getName())) {
-                    // --print
-                    if (options.getOperation() != null) {
-                        throw new RuntimeException("Cannot combine --print with other operations.");
-                    }
-                    options.setOperation(Options.Operations.Print);
+            } else if (currentArg.equals(ArgumentsDeclaration.formattingArg.getName())) {
+                // --formatting
+                String formatting = getArgumentValue(arguments, i++);
+                if (formatting.equals("color") || formatting.equals("colour")) {
+                    options.setFormatter(new ColorFormatter(System.out));
+                } else if (formatting.equals("html")) {
+                    options.setFormatter(new HtmlFormatter(System.out));
+                } else if (!formatting.equals("plain")) {
+                    throw new RuntimeException("Unexpected formatting specified.");
+                }
 
-                } else if (currentArg.equals(ArgumentsDeclaration.virtualArg.getName())) {
-                    // --virtual
-                    options.setPrintVirtual(true);
+            } else if (currentArg.equals(ArgumentsDeclaration.useDefaultBuildArg.getName())) {
+                // --use-default-build
+                options.setUseDefaultBuild(Boolean.parseBoolean(getArgumentValue(arguments, i++)));
 
-                } else if (currentArg.equals(ArgumentsDeclaration.pathArg.getName())) {
-                    // --path
-                    options.setJobsPath(getArgumentValue(arguments, i++));
-
-                } else if (currentArg.equals(ArgumentsDeclaration.historyArg.getName())) {
-                    // --history
-                    options.setNumberOfBuilds(Integer.parseInt(getArgumentValue(arguments, i++)));
-
-                } else if (currentArg.equals(ArgumentsDeclaration.skipFailedArg.getName())) {
-                    // --skip-failed
-                    if (!Boolean.parseBoolean(getArgumentValue(arguments, i++))) {
-                        // if skip failed = false, any result value is taken, so .*
-                        options.getConfiguration("result").setValue(".*");
-                    }
-
-                } else if (currentArg.equals(ArgumentsDeclaration.forceArg.getName())) {
-                    // --force
-                    options.setForceVague(true);
-
-                } else if (currentArg.equals(ArgumentsDeclaration.onlyVolatileArg.getName())) {
-                    // --only-volatile
-                    options.setOnlyVolatile(Boolean.parseBoolean(getArgumentValue(arguments, i++)));
-
-                } else if (currentArg.equals(ArgumentsDeclaration.exactTestsArg.getName())) {
-                    // --exact-tests
-                    options.setExactTestsRegex(getArgumentValue(arguments, i++));
-
-                } else if (currentArg.equals(ArgumentsDeclaration.formattingArg.getName())) {
-                    // --formatting
-                    String formatting = getArgumentValue(arguments, i++);
-                    if (formatting.equals("color") || formatting.equals("colour")) {
-                        options.setFormatter(new ColorFormatter(System.out));
-                    } else if (formatting.equals("html")) {
-                        options.setFormatter(new HtmlFormatter(System.out));
-                    } else if (!formatting.equals("plain")) {
-                        throw new RuntimeException("Unexpected formatting specified.");
-                    }
-
-                } else if (currentArg.equals(ArgumentsDeclaration.useDefaultBuildArg.getName())) {
-                    // --use-default-build
-                    options.setUseDefaultBuild(Boolean.parseBoolean(getArgumentValue(arguments, i++)));
-
-                } else if (currentArg.equals(ArgumentsDeclaration.buildConfigFindArg.getName()) ||
-                        currentArg.equals(ArgumentsDeclaration.jobConfigFindArg.getName())) {
-                    // --X-config-find
-                    String[] values = getArgumentValue(arguments, i++).split(":");
-                    Options.Configuration configuration = getConfiguration(values, currentArg);
-                    // (whatToFind, configuration)
+            } else if (currentArg.equals(ArgumentsDeclaration.buildConfigFindArg.getName()) ||
+                    currentArg.equals(ArgumentsDeclaration.jobConfigFindArg.getName())) {
+                // --X-config-find
+                String[] values = getArgumentValue(arguments, i++).split(":");
+                Options.Configuration configuration = createConfiguration(values, currentArg);
+                // (whatToFind, configuration)
+                if (options.getConfiguration(values[1]) == null) {
                     options.addConfiguration(values[1], configuration);
-                    dynamicArgs.add(values[1]);
+                } else {
+                    throw new RuntimeException("The configuration for " + values[1] + " already exists.");
+                }
 
                     // parsing arguments of the jobs providers
-                } else if (JobsByQuery.getSupportedArgsStatic().contains(currentArg) || JobsByRegex.getSupportedArgsStatic().contains(currentArg)) {
-                    // add a jobs provider to options, if there is none
-                    if (options.getJobsProvider() == null) {
-                        if (JobsByQuery.getSupportedArgsStatic().contains(currentArg)) {
-                            options.setJobsProvider(new JobsByQuery());
-                        } else if (JobsByRegex.getSupportedArgsStatic().contains(currentArg)){
-                            options.setJobsProvider(new JobsByRegex());
-                        }
-                    }
-                    // check if the argument is compatible with current jobs provider
-                    if (options.getJobsProvider().getSupportedArgs().contains(currentArg)) {
-                        options.getJobsProvider().parseArguments(currentArg, getArgumentValue(arguments, i++));
-
-                    } else {
-                        throw new RuntimeException("Cannot combine arguments from multiple job providers.");
-                    }
-
-                } else {
-                    // check if the argument is one of the dynamic arguments
-                    String strippedArg = currentArg.replaceAll("-", "");
-                    if (dynamicArgs.contains(strippedArg)) {
-                        Options.Configuration configuration = options.getConfiguration(strippedArg);
-                        if (configuration != null) {
-                            configuration.setValue(getArgumentValue(arguments, i++));
-                        } else {
-                            throw new RuntimeException("Cannot find configuration for argument " + currentArg + ". Please set it first with --build-config-find or --job-config-find.");
-                        }
-                    } else {
-                        // unknown argument
-                        throw new RuntimeException("Unknown argument " + currentArg + ", run with --help for info.");
+            } else if (JobsByQuery.getSupportedArgsStatic().contains(currentArg) || JobsByRegex.getSupportedArgsStatic().contains(currentArg)) {
+                // add a jobs provider to options, if there is none
+                if (options.getJobsProvider() == null) {
+                    if (JobsByQuery.getSupportedArgsStatic().contains(currentArg)) {
+                        options.setJobsProvider(new JobsByQuery());
+                    } else if (JobsByRegex.getSupportedArgsStatic().contains(currentArg)){
+                        options.setJobsProvider(new JobsByRegex());
                     }
                 }
+                // check if the argument is compatible with current jobs provider
+                if (options.getJobsProvider().getSupportedArgs().contains(currentArg)) {
+                    options.getJobsProvider().parseArguments(currentArg, getArgumentValue(arguments, i++));
 
+                } else {
+                    throw new RuntimeException("Cannot combine arguments from multiple job providers.");
+                }
+
+            } else {
+                if (!arguments[i + 1].matches("^--.*")) {
+                    // these arguments can be dynamic arguments, that were not defined yet
+                    // putting them into the map and checking later
+                    otherArgs.put(currentArg, getArgumentValue(arguments, i++));
+                } else {
+                    // only arguments with some value can now be legal, so if no value was present, throw
+                    throw new RuntimeException("Unknown argument " + currentArg + ", run with --help for info.");
+                }
             }
-        } else {
-            throw new RuntimeException("Expected some arguments.");
+        }
+
+        for (Map.Entry<String, String> entry : otherArgs.entrySet()) {
+            // check if the argument is one of the dynamic arguments
+            String strippedArg = entry.getKey().replaceAll("-", "");
+
+            Options.Configuration configuration = options.getConfiguration(strippedArg);
+            if (configuration != null) {
+                configuration.setValue(entry.getValue());
+            } else {
+                // unknown argument
+                throw new RuntimeException("Unknown argument " + entry.getKey() + ", run with --help for info.");
+            }
         }
 
         // check for basic errors
@@ -178,7 +188,7 @@ public class ArgumentsParsing {
         return options;
     }
 
-    private static Options.Configuration getConfiguration(String[] values, String currentArg) {
+    private static Options.Configuration createConfiguration(String[] values, String currentArg) {
         Options.Configuration configuration;
         // checks the number of items it got from the splitting of the value
         if (values.length == 3) { // filename:whatToFind:findQuery
@@ -199,7 +209,7 @@ public class ArgumentsParsing {
     }
 
     private static String getArgumentValue(String[] arguments, int i) {
-        if (i + 1 < arguments.length) {
+        if (i + 1 < arguments.length && !arguments[i + 1].matches("^--.*")) {
             return arguments[i + 1];
         } else {
             throw new RuntimeException("Expected some value after " + arguments[i] + " argument.");

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
@@ -29,6 +29,6 @@ final public class Constants {
     public static final String REPORT_TESTS_LIST_JSON = "tests-list.json";
     public static final String IRRELEVANT_GLOB_STRING = "report-{runtime,devtools,compiler}.xml.gz";
     public static final double VAGUE_QUERY_THRESHOLD = 0.5;
-
     public static final int VAGUE_QUERY_LENGTH_THRESHOLD = 4;
+    public static final String ESCAPE_DIRECTORY_REGEX = "((\\.\\./)+.*(\\.\\./)*.*)|((\\.\\./)*.*(\\.\\./)+.*)";
 }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ConfigItem.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ConfigItem.java
@@ -14,6 +14,11 @@ public class ConfigItem extends AbstractDescribableImpl<ConfigItem> {
 
     @DataBoundConstructor
     public ConfigItem(String configFileName, String whatToFind, String findQuery, String configLocation) {
+        // check if the user is trying to escape the current directory with ../
+        if (configFileName.matches(Constants.ESCAPE_DIRECTORY_REGEX)) {
+            throw new RuntimeException("Cannot escape from the directory with config file to its parent directory.");
+        }
+
         this.configFileName = configFileName;
         this.whatToFind = whatToFind;
         this.findQuery = findQuery;

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -62,8 +62,8 @@
             <f:entry title="The directory with the config file" field="configLocation"
                      help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/configLocation">
                 <select name="configLocation">
-                    <option value="build">Build directory</option>
-                    <option value="job">Job directory</option>
+                    <option value="build" selected="${instance.ConfigLocation.equals('build') ? 'true' : null}">Build directory</option>
+                    <option value="job" selected="${instance.ConfigLocation.equals('job') ? 'true' : null}">Job directory</option>
                 </select>
             </f:entry>
             <f:entry field="whatToFind" title="Name of the item to find"

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -6,7 +6,7 @@
         </f:entry>
     </f:section>
 
-    <f:section title="Comparator links">
+    <f:section title="Comparator Links">
         <div>
             <p>
                 This section is used for generating automatic links to the comparator tool with prefilled arguments.
@@ -48,7 +48,8 @@
             <p>
                 This section is used for automatically generating "<code>--build-config-find</code>" and "<code>--job-config-find</code>"
                 arguments into the link to comparator, that are above, since writing it manually can clutter the field
-                very easily. Each of these will generate the arguments into EVERY link specified above.
+                very easily. Each of these will generate the arguments into EVERY link specified above. After specifying them,
+                you can also use them as a macro in the arguments field in the <i>comparator links</i> section.
             </p>
             <p>
                 <i>Each field in the form below has a help button describing what should be filled in.</i>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-comparatorArguments.html
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-comparatorArguments.html
@@ -7,7 +7,8 @@
     <p>
         On top of the normal arguments, there is also a type of <b>macro system</b>. This macro system is powerful and
         can be used for making the link dynamic. These macros represent each part of the split job name (split by the
-        spliterator) and when loading the report page, they are replaced by it.
+        spliterator) or a value from config defined in the <i>config items</i> section, and when loading the report
+        page, they are replaced by it.
     </p>
     <i>The macros have this syntax:</i><br>
     <ul>
@@ -20,20 +21,27 @@
 
         <li>"<code>%{S}</code>" or "<code>%{SPLIT}</code>" will be replaced with the spliterator specified in the field
             above.</li>
+
+        <li>"<code>%{dynamic}</code>", where you replace <code>dynamic</code> with a name of an item specified in the
+            <i>config items</i> section (specifically the name from the <i>Name of the item to find</i> field).
+            It will be replaced by a value from the corresponding config file from the current job and build.</li>
     </ul>
     <p>
         <i>Example of the macros:</i><br>
-        For the job name "<code>jtreg~full-jp11-ojdk11~rpms-f36.x86_64-fastdebug.sdk-f36.x86_64.testfarm-x11.defaultgc.legacy.lnxagent.jfroff</code>",<br>
-        and spliterator set to "<code>[.-]</code>", the macros "<code>%{2}%{S}%{N-1}_something_%{N}</code>" will be
-        replaced with "<code>jp11[.-]lnxagent_something_jfroff</code>".
+        There is a job with the job name "<code>jtreg~full-jp11-ojdk11~rpms-f36.x86_64-fastdebug.sdk-f36.x86_64.testfarm-x11.defaultgc.legacy.lnxagent.jfroff</code>",<br>
+        spliterator set to "<code>[.-]</code>" and a config item with the <i>Name of the item to find</i> field set
+        to "<code>nvr</code>" and its evaluation in the config file being "<code>java-17-openjdk-17.0.6.0.9-0.4.ea.el8</code>".
+    </p>
+    <p>
+        The macros "<code>%{2}%{S}%{N-1}_something_%{N} - %{nvr}</code>" will be
+        replaced with "<code>jp11[.-]lnxagent_something_jfroff - java-17-openjdk-17.0.6.0.9-0.4.ea.el8</code>".
     </p>
     <p>
         <i>So an example of the whole prompt with arguments can look like this:</i><br>
         <code>
             --compare<br>
             --history 5<br>
-            --build-config-find changelog.xml:nvr:/build/nvr<br>
-            --nvr ".*"<br>
+            --nvr "%{nvr}"<br>
             --formatting html<br>
             --regex %{1}%{S}%{2}%{S}%{3}%{S}.*%{S}%{5}%{S}%{6}%{S}%{7}%{S}.*%{S}%{9}%{S}%{10}%{S}%{11}%{S}%{12}%{S}%{13}%{S}%{14}%{S}%{15}<br>
         </code>


### PR DESCRIPTION
# Added dynamic macros into Jenkins config
The main feature. Now, when setting links to the comparator tool in the Jenkins config, you can use macros which will correspond with the config items set in the section below.

So now, when you for example set a way to look for nvr in the Config items section of Jenkins config and you put `nvr` into the "Name of the item to find" field. You can use the macro `%{nvr}` in the comparator links section, which will translate into the nvr of the current job and build according to the report page.

## Added a check for escaping the directory
I also added a basic check to stop potential nefarious users from trying to escape directory when using the `--build-config-find`/`--job-config-find` or the "Config items" setting in Jenkins. It checks with regex whether there is `../` in the path to the file and if so, it throws an exception.

## Reworked comparator argument parsing
Till now, the `--build-config-find` arguments had to declared before using the dynamic argument itself (for example `--nvr`). Now it doesnt matter, you can use `--nvr` before declaring `--build-config-find changelog.xml:nvr:/build/nvr`.

## Other
- Fixed a bug where the dropdown menu in Jenkins config did not save the value.
- Updated help message of comparator and Jenkins