### PR TITLE
Showing the build's properties when printing table

### DIFF
--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/VariantComparator.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/VariantComparator.java
@@ -34,7 +34,7 @@ public class VariantComparator {
             // do the chosen operation
             if (options.getOperation() == Options.Operations.List || options.getOperation() == Options.Operations.Compare) {
                 FailedTests.printFailedTable(
-                        FailedTests.createFailedMap(buildsToCompare, options.isOnlyVolatile(), options.getExactTestsRegex(), options.getFormatter()),
+                        FailedTests.createFailedMap(buildsToCompare, options),
                         options.getOperation(), options.getFormatter());
             } else if (options.getOperation() == Options.Operations.Enumerate) {
                 JobsPrinting.printVariants(options.getJobsProvider().getJobs(), options.getFormatter());
@@ -45,7 +45,7 @@ public class VariantComparator {
             // print virtual table
             if (options.isPrintVirtual()) {
                 options.getFormatter().println();
-                VirtualJobsResults.printVirtualTable(buildsToCompare, options.getFormatter(), options.getConfiguration("result"));
+                VirtualJobsResults.printVirtualTable(buildsToCompare, options);
             }
         }
     }

--- a/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
+++ b/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
@@ -100,6 +100,7 @@ public class PrintTableTest {
                 "<li><b>2:</b> second item</li>\n" +
                 "<li><b>3:</b> third item</li>\n" +
                 "</ul>\n" +
+                "<button onclick='expandOrCollapse()' style='margin-bottom:25px'>expand / collapse all</button>\n" +
                 "<table>\n" +
                 "<tr>\n" +
                 "<td></td>\n" +
@@ -126,7 +127,24 @@ public class PrintTableTest {
                 "<td>X</td>\n" +
                 "</tr>\n" +
                 "</table>\n" +
-                "</div>\n",
+                "</div>\n" +
+                "<script>\n" +
+                "let opened = false;\n" +
+                "\n" +
+                "function expandOrCollapse() {\n" +
+                "    let detailsElements = document.querySelectorAll('details');\n" +
+                "\n" +
+                "    detailsElements.forEach((detailsElement) => {\n" +
+                "        if (opened) {\n" +
+                "            detailsElement.removeAttribute('open');\n" +
+                "        } else {\n" +
+                "            detailsElement.setAttribute('open', '');\n" +
+                "        }\n" +
+                "    });\n" +
+                "\n" +
+                "    opened = !opened;\n" +
+                "}\n" +
+                "</script>\n",
                 crlfToLf(outStream.toString()));
     }
 }

--- a/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
+++ b/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
@@ -39,12 +39,12 @@ public class PrintTableTest {
         f.printTable(newTable, 4, 4);
 
         Assertions.assertEquals("1) first item\n" +
-                "2) second item\n" +
-                "3) third item\n" +
-                "           | 1 | 2                                                    | 3 | \n" +
-                "second row | X | this is a very long text in a center cell of a table | X | \n" +
-                "third row  |   |                                                      | X | \n" +
-                "fourth row | X | X                                                    | X | \n",
+                        "2) second item\n" +
+                        "3) third item\n" +
+                        "           | 1 | 2                                                    | 3 | \n" +
+                        "second row | X | this is a very long text in a center cell of a table | X | \n" +
+                        "third row  |   |                                                      | X | \n" +
+                        "fourth row | X | X                                                    | X | \n",
                 crlfToLf(outStream.toString()));
     }
 
@@ -57,12 +57,12 @@ public class PrintTableTest {
         f.printTable(table, 4, 4);
 
         Assertions.assertEquals("\u001B[1m1) \u001B[0mfirst item\n" +
-                "\u001B[1m2) \u001B[0msecond item\n" +
-                "\u001B[1m3) \u001B[0mthird item\n" +
-                "           | \u001B[1m1\u001B[0m | \u001B[1m2\u001B[0m                                                    | \u001B[1m3\u001B[0m | \n" +
-                "second row | \u001B[31mX\u001B[0m | this is a very long text in a center cell of a table | \u001B[31mX\u001B[0m | \n" +
-                "third row  |   |                                                      | \u001B[31mX\u001B[0m | \n" +
-                "fourth row | \u001B[31mX\u001B[0m | \u001B[31mX\u001B[0m                                                    | \u001B[31mX\u001B[0m | \n",
+                        "\u001B[1m2) \u001B[0msecond item\n" +
+                        "\u001B[1m3) \u001B[0mthird item\n" +
+                        "           | \u001B[1m1\u001B[0m | \u001B[1m2\u001B[0m                                                    | \u001B[1m3\u001B[0m | \n" +
+                        "second row | \u001B[31mX\u001B[0m | this is a very long text in a center cell of a table | \u001B[31mX\u001B[0m | \n" +
+                        "third row  |   |                                                      | \u001B[31mX\u001B[0m | \n" +
+                        "fourth row | \u001B[31mX\u001B[0m | \u001B[31mX\u001B[0m                                                    | \u001B[31mX\u001B[0m | \n",
                 crlfToLf(outStream.toString()));
     }
 
@@ -74,7 +74,27 @@ public class PrintTableTest {
 
         f.printTable(table, 4, 4);
 
-        Assertions.assertEquals("<style>table, td { border: 1px solid black; border-collapse: collapse; padding: 0.5em; }</style>\n" +
+        Assertions.assertEquals("<style>\n" +
+                ".contents {\n" +
+                "    font-family: monospace, monospace;\n" +
+                "}\n" +
+                "\n" +
+                ".blk {\n" +
+                "    color: Black;\n" +
+                "}\n" +
+                "\n" +
+                "details {\n" +
+                "    padding-left: 35px;\n" +
+                "}\n" +
+                "\n" +
+                "table, td {\n" +
+                "    border: 1px solid black;\n" +
+                "    border-collapse: collapse;\n" +
+                "    color: Red;\n" +
+                "    padding: 0.5em;\n" +
+                "}\n" +
+                "</style>\n" +
+                "<div class='contents'>\n" +
                 "<ul>\n" +
                 "<li><b>1:</b> first item</li>\n" +
                 "<li><b>2:</b> second item</li>\n" +
@@ -83,29 +103,30 @@ public class PrintTableTest {
                 "<table>\n" +
                 "<tr>\n" +
                 "<td></td>\n" +
-                "<td><b>1</b></td>\n" +
-                "<td><b>2</b></td>\n" +
-                "<td><b>3</b></td>\n" +
+                "<td class='blk'><b>1</b></td>\n" +
+                "<td class='blk'><b>2</b></td>\n" +
+                "<td class='blk'><b>3</b></td>\n" +
                 "</tr>\n" +
                 "<tr>\n" +
-                "<td>second row</td>\n" +
-                "<td style=\"color:Red\">X</td>\n" +
-                "<td>this is a very long text in a center cell of a table</td>\n" +
-                "<td style=\"color:Red\">X</td>\n" +
+                "<td class='blk'>second row</td>\n" +
+                "<td>X</td>\n" +
+                "<td class='blk'>this is a very long text in a center cell of a table</td>\n" +
+                "<td>X</td>\n" +
                 "</tr>\n" +
                 "<tr>\n" +
-                "<td>third row</td>\n" +
+                "<td class='blk'>third row</td>\n" +
                 "<td></td>\n" +
-                "<td></td>\n" +
-                "<td style=\"color:Red\">X</td>\n" +
+                "<td class='blk'></td>\n" +
+                "<td>X</td>\n" +
                 "</tr>\n" +
                 "<tr>\n" +
-                "<td>fourth row</td>\n" +
-                "<td style=\"color:Red\">X</td>\n" +
-                "<td style=\"color:Red\">X</td>\n" +
-                "<td style=\"color:Red\">X</td>\n" +
+                "<td class='blk'>fourth row</td>\n" +
+                "<td>X</td>\n" +
+                "<td>X</td>\n" +
+                "<td>X</td>\n" +
                 "</tr>\n" +
-                "</table>\n",
+                "</table>\n" +
+                "</div>\n",
                 crlfToLf(outStream.toString()));
     }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
@@ -30,4 +30,25 @@ final public class Constants {
     public static final String IRRELEVANT_GLOB_STRING = "report-{runtime,devtools,compiler}.xml.gz";
     public static final double VAGUE_QUERY_THRESHOLD = 0.5;
     public static final int VAGUE_QUERY_LENGTH_THRESHOLD = 4;
+    public static final String COMPARATOR_TABLE_CSS =
+            "<style>\n" +
+                    ".contents {\n" +
+                    "    font-family: monospace, monospace;\n" +
+                    "}\n" +
+                    "\n" +
+                    ".blk {\n" +
+                    "    color: Black;\n" +
+                    "}\n" +
+                    "\n" +
+                    "details {\n" +
+                    "    padding-left: 35px;\n" +
+                    "}\n" +
+                    "\n" +
+                    "table, td {\n" +
+                    "    border: 1px solid black;\n" +
+                    "    border-collapse: collapse;\n" +
+                    "    color: Red;\n" +
+                    "    padding: 0.5em;\n" +
+                    "}\n" +
+                    "</style>";
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
@@ -31,7 +31,7 @@ final public class Constants {
     public static final double VAGUE_QUERY_THRESHOLD = 0.5;
     public static final int VAGUE_QUERY_LENGTH_THRESHOLD = 4;
     public static final String COMPARATOR_TABLE_CSS =
-            "<style>\n" +
+                    "<style>\n" +
                     ".contents {\n" +
                     "    font-family: monospace, monospace;\n" +
                     "}\n" +
@@ -51,4 +51,22 @@ final public class Constants {
                     "    padding: 0.5em;\n" +
                     "}\n" +
                     "</style>";
+    public static final String COMPARATOR_TABLE_JAVASCRIPT =
+                    "<script>\n" +
+                    "let opened = false;\n" +
+                    "\n" +
+                    "function expandOrCollapse() {\n" +
+                    "    let detailsElements = document.querySelectorAll('details');\n" +
+                    "\n" +
+                    "    detailsElements.forEach((detailsElement) => {\n" +
+                    "        if (opened) {\n" +
+                    "            detailsElement.removeAttribute('open');\n" +
+                    "        } else {\n" +
+                    "            detailsElement.setAttribute('open', '');\n" +
+                    "        }\n" +
+                    "    });\n" +
+                    "\n" +
+                    "    opened = !opened;\n" +
+                    "}\n" +
+                    "</script>";
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/BasicFormatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/BasicFormatter.java
@@ -24,6 +24,7 @@
 package io.jenkins.plugins.report.jtreg.formatters;
 
 import java.io.PrintStream;
+import java.util.List;
 
 public abstract class BasicFormatter implements Formatter {
 
@@ -56,7 +57,7 @@ public abstract class BasicFormatter implements Formatter {
 
     @Override
     public void small(){
-        
+
     }
 
     @Override
@@ -72,5 +73,10 @@ public abstract class BasicFormatter implements Formatter {
     @Override
     public void printTable(String[][] table, int rowSize, int columnSize) {
 
+    }
+
+    @Override
+    public String generateTableHeaderItem(String mainLine, List<String> otherLines) {
+        return "";
     }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/ColorFormatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/ColorFormatter.java
@@ -25,6 +25,7 @@ package io.jenkins.plugins.report.jtreg.formatters;
 
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.List;
 
 public class ColorFormatter extends StringMappedFormatter {
 //those are NOT spaces but bash \e
@@ -170,4 +171,18 @@ public class ColorFormatter extends StringMappedFormatter {
         }
     }
 
+    @Override
+    public String generateTableHeaderItem(String mainLine, List<String> otherLines) {
+        StringBuilder headerItem = new StringBuilder();
+
+        // main line
+        headerItem.append(Bold).append(Green).append(mainLine).append(ResetAll);
+
+        // other lines
+        for (String line : otherLines) {
+            headerItem.append("\n\t\t").append(Cyan).append(line).append(ResetAll);
+        }
+
+        return headerItem.toString();
+    }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/Formatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/Formatter.java
@@ -23,6 +23,8 @@
  */
 package io.jenkins.plugins.report.jtreg.formatters;
 
+import java.util.List;
+
 public interface Formatter {
 
     public enum SupportedColors {
@@ -73,4 +75,5 @@ public interface Formatter {
     public void preClose();
 
     public void printTable(String[][] table, int rowSize, int columnSize);
+    public String generateTableHeaderItem(String mainLine, List<String> otherLines);
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
@@ -23,6 +23,8 @@
  */
 package io.jenkins.plugins.report.jtreg.formatters;
 
+import io.jenkins.plugins.report.jtreg.Constants;
+
 import java.io.PrintStream;
 import java.util.LinkedList;
 import java.util.List;
@@ -138,7 +140,9 @@ public class HtmlFormatter extends StringMappedFormatter {
 
     @Override
     public void printTable(String[][] table, int rowSize, int columnSize) {
-        super.println("<style>table, td { border: 1px solid black; border-collapse: collapse; padding: 0.5em; }</style>");
+        super.println(Constants.COMPARATOR_TABLE_CSS); // print styles
+
+        super.println("<div class='contents'>"); // start the section
 
         // first print the first row definitions
         super.println("<ul>");
@@ -148,16 +152,16 @@ public class HtmlFormatter extends StringMappedFormatter {
         }
         super.println("</ul>");
 
-        // print the table
+        // print the table itself
         super.println("<table>");
         for (int i = 0; i < rowSize; i++) {
             super.println("<tr>");
             for (int j = 0; j < columnSize; j++) {
                 if (table[i][j] != null) {
                     if (table[i][j].equals("X")) {
-                        super.println("<td style=\"color:Red\">" + table[i][j] + "</td>");
-                    } else {
                         super.println("<td>" + table[i][j] + "</td>");
+                    } else {
+                        super.println("<td class='blk'>" + table[i][j] + "</td>");
                     }
                 } else {
                     super.println("<td></td>");
@@ -166,5 +170,25 @@ public class HtmlFormatter extends StringMappedFormatter {
             super.println("</tr>");
         }
         super.println("</table>");
+
+        super.println("</div>"); // end the section
+    }
+
+    @Override
+    public String generateTableHeaderItem(String mainLine, List<String> otherLines) {
+        StringBuilder headerItem = new StringBuilder();
+
+        // main line
+        headerItem.append("<b style='color:Green'>").append(mainLine).append("</b><br>");
+
+        // other lines, hidden by default
+        headerItem.append("<details>");
+        headerItem.append("<summary style='color:DodgerBlue'>properties</summary>");
+        for (String line : otherLines) {
+            headerItem.append(line).append("<br>");
+        }
+        headerItem.append("</details>");
+
+        return headerItem.toString();
     }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
@@ -152,6 +152,8 @@ public class HtmlFormatter extends StringMappedFormatter {
         }
         super.println("</ul>");
 
+        super.println("<button onclick='expandOrCollapse()' style='margin-bottom:25px'>expand / collapse all</button>");
+
         // print the table itself
         super.println("<table>");
         for (int i = 0; i < rowSize; i++) {
@@ -169,9 +171,10 @@ public class HtmlFormatter extends StringMappedFormatter {
             }
             super.println("</tr>");
         }
-        super.println("</table>");
 
+        super.println("</table>");
         super.println("</div>"); // end the section
+        super.println(Constants.COMPARATOR_TABLE_JAVASCRIPT); // print the javascript to expand/collapse the properties
     }
 
     @Override

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/PlainFormatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/PlainFormatter.java
@@ -25,6 +25,7 @@ package io.jenkins.plugins.report.jtreg.formatters;
 
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.List;
 
 public class PlainFormatter extends BasicFormatter {
 
@@ -114,5 +115,20 @@ public class PlainFormatter extends BasicFormatter {
             }
             super.print("\n");
         }
+    }
+
+    @Override
+    public String generateTableHeaderItem(String mainLine, List<String> otherLines) {
+        StringBuilder headerItem = new StringBuilder();
+
+        // main line
+        headerItem.append(mainLine);
+
+        // other lines
+        for (String line : otherLines) {
+            headerItem.append("\n\t\t").append(line);
+        }
+
+        return headerItem.toString();
     }
 }


### PR DESCRIPTION
# Showing the build's properties when printing table

When using the `--compare` or `--virtual` switch, now it not only shows the job name and build number, but also every property of this job (the stuff set with `--build-config-find` or `--job-config-find`). The "result" property is set by default, so it will be always shown.

Example in plain formatting:
```
20) reproducers~regular-jp11-ojdk11~rpms-f36.x86_64-release.sdk-f36.x86_64.testfarm-x11.defaultgc.defaultcp.lnxagent.jfroff - build:63
                result : UNSTABLE
                version : 11
21) tck-jp17-ojdk17~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.beaker-x11.defaultgc.fips.lnxagent.jfroff - build:14
                result : UNSTABLE
                version : 17
22) tck-jp17-ojdk17~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.beaker-x11.defaultgc.fips.lnxagent.jfroff - build:16
                result : UNSTABLE
                version : 17
```

Example in HTML formatting (clickable with the `<details>` and `<summary>` elements):
![Screenshot from 2024-03-13 14-06-24](https://github.com/jenkinsci/report-jtreg-plugin/assets/115928463/0a8dea26-b9be-4230-8ac3-ff3562dd33e7)
