### PR TITLE
Showing passed builds in the compare table

### DIFF
--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/FailedTests.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/FailedTests.java
@@ -87,7 +87,12 @@ public class FailedTests {
     }
 
     // function for getting the HashMap of failed tests ready for printing to console
-    public static void printFailedTable(HashMap<String, ArrayList<String>> failedMap, Options.Operations operation, Formatter formatter) {
+    public static void printFailedTable(HashMap<String, ArrayList<String>> failedMap, Options options) {
+        // by default, all builds are shown, this makes the table less "cluttery" by deleting builds with no failed tests
+        if (options.isHidePasses()) {
+            failedMap.entrySet().removeIf(entry -> entry.getValue().isEmpty());
+        }
+
         // get all non-duplicate failed tests from the map
         Set<String> nonRepeatingValues = new HashSet<>();
         for (ArrayList<String> values : failedMap.values()) {
@@ -103,7 +108,7 @@ public class FailedTests {
         Collections.sort(keys);
 
         // if the operation is "compare" (rows are failed tests and columns builds), switch the values and keys
-        if (operation == Options.Operations.Compare) {
+        if (options.getOperation() == Options.Operations.Compare) {
             List<String> temp = keys;
             keys = sortedValues;
             sortedValues = temp;
@@ -124,7 +129,7 @@ public class FailedTests {
 
             // now, create a list of values where to put the X for each column
             List<String> putXList = new ArrayList<>();
-            if (operation == Options.Operations.Compare) {
+            if (options.getOperation() == Options.Operations.Compare) {
                 // if the operation is compare, the values to put X are the builds (or the keys in the map),
                 // so it has to go through the map and find them
                 for (Map.Entry<String, ArrayList<String>> entry : failedMap.entrySet()) {
@@ -146,6 +151,6 @@ public class FailedTests {
         }
 
         // print the table into stdout
-        formatter.printTable(table, keys.size() + 1, sortedValues.size() + 1);
+        options.getFormatter().printTable(table, keys.size() + 1, sortedValues.size() + 1);
     }
 }

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/FailedTests.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/FailedTests.java
@@ -86,68 +86,66 @@ public class FailedTests {
         return failedMap;
     }
 
-    // function for reversing the HashMap from reverseFailedMap() method
-    // Keys: Failed test names, Values: list of builds where the test failed
-    private static HashMap<String, ArrayList<String>> reverseFailedMap(HashMap<String, ArrayList<String>> failedMap) {
-        HashMap<String, ArrayList<String>> reversedMap = new HashMap<>();
-
-        ArrayList<String> allFailed = new ArrayList<>();
-        for (ArrayList<String> tests : failedMap.values()) {
-            for (String test : tests) {
-                if(!allFailed.contains(test)) {
-                    allFailed.add(test);
-                }
-            }
-        }
-
-        for (String test : allFailed) {
-            ArrayList<String> testBuilds = new ArrayList<>();
-            for (Map.Entry<String, ArrayList<String>> entry : failedMap.entrySet()) {
-                if (entry.getValue().contains(test)) {
-                    testBuilds.add(entry.getKey());
-                }
-            }
-            reversedMap.put(test, testBuilds);
-        }
-
-        return reversedMap;
-    }
-
     // function for getting the HashMap of failed tests ready for printing to console
     public static void printFailedTable(HashMap<String, ArrayList<String>> failedMap, Options.Operations operation, Formatter formatter) {
-        if (operation == Options.Operations.Compare) {
-            failedMap = reverseFailedMap(failedMap);
+        // get all non-duplicate failed tests from the map
+        Set<String> nonRepeatingValues = new HashSet<>();
+        for (ArrayList<String> values : failedMap.values()) {
+            nonRepeatingValues.addAll(values);
         }
 
-        ArrayList<String> allFailedTests = new ArrayList<>();
-        for (ArrayList<String> tests : failedMap.values()) {
-            for (String test : tests) {
-                if(!allFailedTests.contains(test)) {
-                    allFailedTests.add(test);
-                }
-            }
-        }
-        Collections.sort(allFailedTests);
+        // sort the failed tests set
+        List<String> sortedValues = new ArrayList<>(nonRepeatingValues);
+        Collections.sort(sortedValues);
 
-        String[][] table = new String[failedMap.size() + 1][allFailedTests.size() + 1];
-        // add first line (header)
-        for (int i = 1; i < allFailedTests.size() + 1; i++) {
-            table[0][i] = allFailedTests.get(i - 1);
-        }
-        // add the builds and tests
-        ArrayList<String> keys = new ArrayList<>(failedMap.keySet());
+        // get the key from the map (builds) and sort them
+        List<String> keys = new ArrayList<>(failedMap.keySet());
         Collections.sort(keys);
 
-        // add the "X"s to the table
+        // if the operation is "compare" (rows are failed tests and columns builds), switch the values and keys
+        if (operation == Options.Operations.Compare) {
+            List<String> temp = keys;
+            keys = sortedValues;
+            sortedValues = temp;
+        }
+
+        // create the table itself (2D array), where [rows][columns]
+        String[][] table = new String[keys.size() + 1][sortedValues.size() + 1];
+
+        // first, put values into the table header (first row)
+        for (int i = 1; i < sortedValues.size() + 1; i++) {
+            table[0][i] = sortedValues.get(i - 1);
+        }
+
+        // add the "X"s to the table where the tests fail
         int i = 1;
         for (String key : keys) {
-            table[i][0] = key;
-            for (String test : failedMap.get(key)) {
-                table[i][allFailedTests.indexOf(test) + 1] = "X";
+            table[i][0] = key; // put the key into first column
+
+            // now, create a list of values where to put the X for each column
+            List<String> putXList = new ArrayList<>();
+            if (operation == Options.Operations.Compare) {
+                // if the operation is compare, the values to put X are the builds (or the keys in the map),
+                // so it has to go through the map and find them
+                for (Map.Entry<String, ArrayList<String>> entry : failedMap.entrySet()) {
+                    if (entry.getValue().contains(key)) {
+                        putXList.add(entry.getKey());
+                    }
+                }
+            } else {
+                // otherwise, just get the values from the map
+                putXList = failedMap.get(key);
             }
+
+            // put the Xs itself
+            for (String value : putXList) {
+                table[i][sortedValues.indexOf(value) + 1] = "X";
+            }
+
             i++;
         }
 
-        formatter.printTable(table, failedMap.size() + 1, allFailedTests.size() + 1);
+        // print the table into stdout
+        formatter.printTable(table, keys.size() + 1, sortedValues.size() + 1);
     }
 }

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/HelpMessage.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/HelpMessage.java
@@ -58,6 +58,8 @@ final public class HelpMessage {
             "                  " + ArgumentsDeclaration.exactTestsArg.getHelp() + "\n" +
             "    " + ArgumentsDeclaration.useDefaultBuildArg.getName() + ArgumentsDeclaration.useDefaultBuildArg.getUsage() + "\n" +
             "                  " + ArgumentsDeclaration.useDefaultBuildArg.getHelp() + "\n" +
+            "    " + ArgumentsDeclaration.hidePassesArg.getName() + ArgumentsDeclaration.hidePassesArg.getUsage() + "\n" +
+            "                  " + ArgumentsDeclaration.hidePassesArg.getHelp() + "\n" +
             "\n" +
             "    Dynamic arguments:\n" +
             "        Another type of arguments you can use are dynamic arguments. They are used\n" +

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/Options.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/Options.java
@@ -19,6 +19,7 @@ public class Options {
     private boolean useDefaultBuild;
     private JobsProvider jobsProvider;
     private boolean printVirtual;
+    private boolean hidePasses;
     private boolean die;
     private final Map<String, Configuration> configurations;
 
@@ -31,6 +32,7 @@ public class Options {
         this.useDefaultBuild = false;
         this.jobsProvider = null;
         this.printVirtual = false;
+        this.hidePasses = false;
         this.die = false;
         this.configurations = new HashMap<>();
         // default configuration for getting job results
@@ -121,6 +123,14 @@ public class Options {
 
     public boolean isPrintVirtual() {
         return printVirtual;
+    }
+
+    public void setHidePasses(boolean hidePasses) {
+        this.hidePasses = hidePasses;
+    }
+
+    public boolean isHidePasses() {
+        return hidePasses;
     }
 
     public void setPrintVirtual(boolean printVirtual) {

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/VariantComparator.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/VariantComparator.java
@@ -33,9 +33,7 @@ public class VariantComparator {
         if (!buildsToCompare.isEmpty()) {
             // do the chosen operation
             if (options.getOperation() == Options.Operations.List || options.getOperation() == Options.Operations.Compare) {
-                FailedTests.printFailedTable(
-                        FailedTests.createFailedMap(buildsToCompare, options),
-                        options.getOperation(), options.getFormatter());
+                FailedTests.printFailedTable(FailedTests.createFailedMap(buildsToCompare, options), options);
             } else if (options.getOperation() == Options.Operations.Enumerate) {
                 JobsPrinting.printVariants(options.getJobsProvider().getJobs(), options.getFormatter());
             } else if (options.getOperation() == Options.Operations.Print) {

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsDeclaration.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsDeclaration.java
@@ -18,4 +18,5 @@ public final class ArgumentsDeclaration {
   public static final Argument useDefaultBuildArg = new Argument("--use-default-build", "If set to true and no matching build with given criteria was found, the tool will use the latest (default) build instead. Default value is false.", " <true/false>");
   public static final Argument buildConfigFindArg = new Argument("--build-config-find", "Argument used for declaring dynamic arguments. Looks for the specified config file inside the BUILD directory.", " configFileName:whatAreYouLookingFor:queryToFindIt");
   public static final Argument jobConfigFindArg = new Argument("--job-config-find", "Argument used for declaring dynamic arguments. Looks for the specified config file inside the JOB directory.", " configFileName:whatAreYouLookingFor:queryToFindIt");
+  public static final Argument hidePassesArg = new Argument("--hide-passes", "If set to true, when printing the compare table, only builds with at least one failed test will be shown, passed tests will be hidden to make the table smaller. Set to false by default.", " <true/false>");
 }

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsParsing.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ArgumentsParsing.java
@@ -112,6 +112,10 @@ public class ArgumentsParsing {
                 // --use-default-build
                 options.setUseDefaultBuild(Boolean.parseBoolean(getArgumentValue(arguments, i++)));
 
+            } else if (currentArg.equals(ArgumentsDeclaration.hidePassesArg.getName())) {
+                // --hide-passes
+                options.setHidePasses(Boolean.parseBoolean(getArgumentValue(arguments, i++)));
+
             } else if (currentArg.equals(ArgumentsDeclaration.buildConfigFindArg.getName()) ||
                     currentArg.equals(ArgumentsDeclaration.jobConfigFindArg.getName())) {
                 // --X-config-find
@@ -124,7 +128,7 @@ public class ArgumentsParsing {
                     throw new RuntimeException("The configuration for " + values[1] + " already exists.");
                 }
 
-                    // parsing arguments of the jobs providers
+            // parsing arguments of the jobs providers
             } else if (JobsByQuery.getSupportedArgsStatic().contains(currentArg) || JobsByRegex.getSupportedArgsStatic().contains(currentArg)) {
                 // add a jobs provider to options, if there is none
                 if (options.getJobsProvider() == null) {

--- a/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
+++ b/report-jtreg-comparator/src/test/java/io/jenkins/plugins/report/jtreg/main/comparator/PrintTableTest.java
@@ -96,17 +96,17 @@ public class PrintTableTest {
                 "</style>\n" +
                 "<div class='contents'>\n" +
                 "<ul>\n" +
-                "<li><b>1:</b> first item</li>\n" +
-                "<li><b>2:</b> second item</li>\n" +
-                "<li><b>3:</b> third item</li>\n" +
+                "<li><b id='legend-1'><a href='#table-1'>1:</a></b> first item</li>\n" +
+                "<li><b id='legend-2'><a href='#table-2'>2:</a></b> second item</li>\n" +
+                "<li><b id='legend-3'><a href='#table-3'>3:</a></b> third item</li>\n" +
                 "</ul>\n" +
                 "<button onclick='expandOrCollapse()' style='margin-bottom:25px'>expand / collapse all</button>\n" +
                 "<table>\n" +
                 "<tr>\n" +
                 "<td></td>\n" +
-                "<td class='blk'><b>1</b></td>\n" +
-                "<td class='blk'><b>2</b></td>\n" +
-                "<td class='blk'><b>3</b></td>\n" +
+                "<td class='blk'><b id='table-1'><a href='#legend-1'>1</a></b></td>\n" +
+                "<td class='blk'><b id='table-2'><a href='#legend-2'>2</a></b></td>\n" +
+                "<td class='blk'><b id='table-3'><a href='#legend-3'>3</a></b></td>\n" +
                 "</tr>\n" +
                 "<tr>\n" +
                 "<td class='blk'>second row</td>\n" +

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
@@ -147,8 +147,9 @@ public class HtmlFormatter extends StringMappedFormatter {
         // first print the first row definitions
         super.println("<ul>");
         for (int i = 1; i < table[0].length; i++) {
-            super.println("<li><b>" + i + ":</b> " + table[0][i] + "</li>");
-            table[0][i] = "<b>" + i + "</b>"; // replace the item with its definition (number)
+            // make the definition and the table header linkable between each other
+            super.println("<li><b id='legend-" + i + "'><a href='#table-" + i + "'>" + i + ":</a></b> " + table[0][i] + "</li>");
+            table[0][i] = "<b id='table-" + i + "'><a href='#legend-" + i + "'>" + i + "</a></b>"; // replace the item with its definition (number)
         }
         super.println("</ul>");
 


### PR DESCRIPTION
# Showing passed builds in the compare table

By default, the compare table now also shows builds with no failed tests - an empty column in the table. This can make the table really big, so I added `--hide-passes true` switch, which hides the builds with no failed tests and makes the table smaller (as it was before this pull request).

I also added links (when using html formatter) between the numbers in the table legend (next to the build name and its properties) and numbers in the table header (first row), to make the jumping between those easier when working with large tables.