### PR TITLE
Implemented dynamic links next to failed tests

### DIFF
--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ComparatorArgDeclaration.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ComparatorArgDeclaration.java
@@ -9,7 +9,7 @@ public final class ComparatorArgDeclaration extends CommonArgDeclaration {
   public static final Argument enumerateArg = new Argument("--enumerate", "Print lists of all variants of jobs (that match the rest of arguments).", "");
   public static final Argument compareArg = new Argument("--compare", "Print a table of all failed tests (of matched job builds) and the builds where they failed.", "");
   public static final Argument printArg = new Argument("--print", "Print all jobs and their builds that match the rest of arguments, without actually doing any operation on the builds or tests.", "");
-  public static final Argument virtualArg = new Argument("--virtual", "Print a table of all matched jobs' builds and their result (e.g. SUCCESS, UNSTABLE, etc.). Can be used as standalone operation or combined with any other operation. Probably should be run with --skip-failed=false switch.", "");
+  public static final Argument virtualArg = new Argument("--virtual", "Print a table of all matched jobs' builds and their result (e.g. SUCCESS, UNSTABLE, etc.). Can be used as standalone operation or combined with any other operation. Overrides the default of --skip-failed switch to false.", "");
   public static final Argument historyArg = new Argument("--history", "To specify the maximum number of builds to look in.", " <number>");
   public static final Argument skipFailedArg = new Argument("--skip-failed", "Specify whether the comparator should skip failed tests (only take successful and unstable) or take all. The default value is true.", " <true/false>");
   public static final Argument forceArg = new Argument("--force", "Used for forcing vague requests, that could potentially take a long time.", "");

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ComparatorArgParser.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/arguments/ComparatorArgParser.java
@@ -27,6 +27,8 @@ public class ComparatorArgParser extends CommonArgParser {
 
         Map<String, String> otherArgs = new HashMap<>(); // a list for unmatched (for now) arguments
 
+        boolean manualSkipFailed = false; // variable to know if user set --skip-failed manually
+
         for (int i = 0; i < arguments.length; i++) {
             // delete all leading - characters
             String currentArg = arguments[i].replaceAll("^-+", "--");
@@ -74,6 +76,9 @@ public class ComparatorArgParser extends CommonArgParser {
             } else if (currentArg.equals(ComparatorArgDeclaration.virtualArg.getName())) {
                 // --virtual
                 localOptions.setPrintVirtual(true);
+                if (!manualSkipFailed) {
+                    localOptions.getConfiguration("result").setValue(".*"); // takes all values, even failed (see --skip-failed)
+                }
 
             } else if (currentArg.equals(ComparatorArgDeclaration.historyArg.getName())) {
                 // --history
@@ -81,10 +86,14 @@ public class ComparatorArgParser extends CommonArgParser {
 
             } else if (currentArg.equals(ComparatorArgDeclaration.skipFailedArg.getName())) {
                 // --skip-failed
-                if (!Boolean.parseBoolean(getArgumentValue(i++))) {
+                if (Boolean.parseBoolean(getArgumentValue(i++))) {
+                    // if skip failed = true, only take not-failed values
+                    localOptions.getConfiguration("result").setValue("{SUCCESS,UNSTABLE}");
+                } else {
                     // if skip failed = false, any result value is taken, so .*
                     localOptions.getConfiguration("result").setValue(".*");
                 }
+                manualSkipFailed = true; // --skip-failed was called manually
 
             } else if (currentArg.equals(ComparatorArgDeclaration.forceArg.getName())) {
                 // --force

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
@@ -1,6 +1,9 @@
 package io.jenkins.plugins.report.jtreg;
 
 
+import io.jenkins.plugins.report.jtreg.items.ComparatorLinksGroup;
+import io.jenkins.plugins.report.jtreg.items.ConfigItem;
+import io.jenkins.plugins.report.jtreg.items.TestLink;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -20,6 +23,7 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
     String toolsUrl;
     List<ComparatorLinksGroup> comparatorLinksGroups;
     List<ConfigItem> configItems;
+    List<TestLink> testLinks;
 
     public static JenkinsReportJckGlobalConfig getInstance() {
         return GlobalConfiguration.all().get(JenkinsReportJckGlobalConfig.class);
@@ -76,11 +80,25 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
         this.configItems = configItems;
     }
 
+    public static List<TestLink> getGlobalTestLinks() {
+        return getInstance().getTestLinks();
+    }
+
+    public List<TestLink> getTestLinks() {
+        return testLinks;
+    }
+
+    @DataBoundSetter
+    public void setTestLinks(List<TestLink> testLinks) {
+        this.testLinks = testLinks;
+    }
+
     @DataBoundConstructor
-    public JenkinsReportJckGlobalConfig(String toolsUrl, List<ComparatorLinksGroup> comparatorLinksGroups, List<ConfigItem> configItems) {
+    public JenkinsReportJckGlobalConfig(String toolsUrl, List<ComparatorLinksGroup> comparatorLinksGroups, List<ConfigItem> configItems, List<TestLink> testLinks) {
         this.toolsUrl = toolsUrl;
         this.comparatorLinksGroups = comparatorLinksGroups;
         this.configItems = configItems;
+        this.testLinks = testLinks;
     }
 
     public JenkinsReportJckGlobalConfig() {

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/ComparatorLinksGroup.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/ComparatorLinksGroup.java
@@ -1,4 +1,4 @@
-package io.jenkins.plugins.report.jtreg;
+package io.jenkins.plugins.report.jtreg.items;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/ConfigItem.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/ConfigItem.java
@@ -1,4 +1,4 @@
-package io.jenkins.plugins.report.jtreg;
+package io.jenkins.plugins.report.jtreg.items;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/LinkToComparator.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/LinkToComparator.java
@@ -1,0 +1,54 @@
+package io.jenkins.plugins.report.jtreg.items;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class LinkToComparator extends AbstractDescribableImpl<LinkToComparator> {
+    private String label;
+    private String spliterator;
+    private String comparatorArguments;
+
+    @DataBoundConstructor
+    public LinkToComparator(String label, String spliterator, String comparatorArguments) {
+        this.label = label;
+        this.spliterator = spliterator;
+        this.comparatorArguments = comparatorArguments;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    @DataBoundSetter
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getSpliterator() {
+        return spliterator;
+    }
+
+    @DataBoundSetter
+    public void setSpliterator(String spliterator) {
+        this.spliterator = spliterator;
+    }
+
+    public String getComparatorArguments() {
+        return comparatorArguments;
+    }
+
+    @DataBoundSetter
+    public void setComparatorArguments(String comparatorArguments) {
+        this.comparatorArguments = comparatorArguments;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<LinkToComparator> {
+        public String getDisplayName() {
+            return "Link to comparator tool";
+        }
+    }
+}

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/TestLink.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/items/TestLink.java
@@ -1,4 +1,4 @@
-package io.jenkins.plugins.report.jtreg;
+package io.jenkins.plugins.report.jtreg.items;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -6,16 +6,17 @@ import hudson.model.Descriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-public class LinkToComparator extends AbstractDescribableImpl<LinkToComparator> {
+public class TestLink extends AbstractDescribableImpl<TestLink> {
     private String label;
+    private String basePage;
     private String spliterator;
-    private String comparatorArguments;
+    private String arguments;
 
     @DataBoundConstructor
-    public LinkToComparator(String label, String spliterator, String comparatorArguments) {
+    public TestLink(String label, String spliterator, String arguments) {
         this.label = label;
         this.spliterator = spliterator;
-        this.comparatorArguments = comparatorArguments;
+        this.arguments = arguments;
     }
 
     public String getLabel() {
@@ -27,6 +28,15 @@ public class LinkToComparator extends AbstractDescribableImpl<LinkToComparator> 
         this.label = label;
     }
 
+    public String getBasePage() {
+        return basePage;
+    }
+
+    @DataBoundSetter
+    public void setBasePage(String basePage) {
+        this.basePage = basePage;
+    }
+
     public String getSpliterator() {
         return spliterator;
     }
@@ -36,19 +46,17 @@ public class LinkToComparator extends AbstractDescribableImpl<LinkToComparator> 
         this.spliterator = spliterator;
     }
 
-    public String getComparatorArguments() {
-        return comparatorArguments;
+    public String getArguments() {
+        return arguments;
     }
 
     @DataBoundSetter
-    public void setComparatorArguments(String comparatorArguments) {
-        this.comparatorArguments = comparatorArguments;
+    public void setArguments(String arguments) {
+        this.arguments = arguments;
     }
 
     @Extension
-    public static class DescriptorImpl extends Descriptor<LinkToComparator> {
-        public String getDisplayName() {
-            return "Link to comparator tool";
-        }
+    public static class DescriptorImpl extends Descriptor<TestLink> {
+        public String getDisplayName() { return "Link next to a failed test"; }
     }
 }

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
@@ -70,7 +70,9 @@
                                                 document.getElementById('button_expand_${suitesStatus.count}_${testStatus.count}').style.display = 'inline';
                                                 return false;">(collapse)</a>
                                         <j:if test="${it.isDiffTool()}">
-                                          <a target="_blank" href="${it.getTrackingUrl(t)}" style="font-size: smaller;" >(track)</a>
+                                            <j:forEach var="tl" items="${it.getAllTestLinks()}">
+                                                <a target="_blank" href="${it.createTestLinkUrl(tl, t.name)}" style="font-size: smaller;" >(${tl.getLabel()})</a>
+                                            </j:forEach>
                                         </j:if>
                                         <div id="details_${suitesStatus.count}_${testStatus.count}" style="display: none">
                                             <ul>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -84,7 +84,7 @@
             <p>
                 This section is used for generating automatic links which will be shown next to all failed tests on the jtreg report page.
                 It uses the same macro system as described in the <i>Comparator Links</i> section
-                (there is a new specific macro, <code>%{TESTNAME}</code> for getting a name of the test),
+                (there is a specific macro, <code>%{TESTNAME}</code> for getting a name of the test),
                 however, these links can lead to any tool, not just the comparator.
             </p>
             <p>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -83,7 +83,9 @@
         <div>
             <p>
                 This section is used for generating automatic links which will be shown next to all failed tests on the jtreg report page.
-                It uses the same macro system as described in the <i>Comparator Links</i> section, however, these links can lead to any tool, not just the comparator.
+                It uses the same macro system as described in the <i>Comparator Links</i> section
+                (there is a new specific macro, <code>%{TESTNAME}</code> for getting a name of the test),
+                however, these links can lead to any tool, not just the comparator.
             </p>
             <p>
                 <i>Each field in the form below has a help button describing what should be filled in.</i>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -34,7 +34,7 @@
                     <f:textbox />
                 </f:entry>
                 <f:entry field="comparatorArguments" title="Comparator tool arguments (one on each line)"
-                         help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/comparatorArguments">
+                         help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/arguments">
                     <f:textarea />
                 </f:entry>
                 <f:repeatableDeleteButton/>
@@ -74,6 +74,37 @@
             <f:entry field="findQuery" title="XPath/JSON query/properties key to find the item in the config file"
                      help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/findQuery">
                 <f:textbox />
+            </f:entry>
+            <f:repeatableDeleteButton/>
+        </f:repeatable>
+    </f:section>
+
+    <f:section title="Failed Test Links">
+        <div>
+            <p>
+                This section is used for generating automatic links which will be shown next to all failed tests on the jtreg report page.
+                It uses the same macro system as described in the <i>Comparator Links</i> section, however, these links can lead to any tool, not just the comparator.
+            </p>
+            <p>
+                <i>Each field in the form below has a help button describing what should be filled in.</i>
+            </p>
+        </div>
+        <f:repeatable field="testLinks">
+            <f:entry field="label" title="Link label"
+                     help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/failedTestLinkLabel">
+                <f:textbox />
+            </f:entry>
+            <f:entry field="basePage" title="Base tool page"
+                     help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/failedTestLinkUrl">
+                <f:textbox />
+            </f:entry>
+            <f:entry field="spliterator" title="A spliterator to split the job names"
+                     help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/spliterator">
+                <f:textbox />
+            </f:entry>
+            <f:entry field="arguments" title="Tool arguments (one on each line)"
+                     help="/descriptor/io.jenkins.plugins.report.jtreg.JenkinsReportJckGlobalConfig/help/arguments">
+                <f:textarea />
             </f:entry>
             <f:repeatableDeleteButton/>
         </f:repeatable>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-arguments.html
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-arguments.html
@@ -1,6 +1,6 @@
 <div>
     <p>
-        As the label suggests, you can write any command line argument of the comparator tool here. Each argument
+        As the label suggests, you can write any command line argument of the comparator tool (or other tool in the case of failed test links) here. Each argument
         should be on its own separate line. The available arguments can be seen in the comparator help message (you can
         see this message when running comparator with the <code>--help</code> argument).
     </p>
@@ -21,6 +21,11 @@
 
         <li>"<code>%{S}</code>" or "<code>%{SPLIT}</code>" will be replaced with the spliterator specified in the field
             above.</li>
+
+        <li>"<code>%{JOBNAME}</code>" will be replaced with the full job name.</li>
+
+        <li>"<code>%{TESTNAME}</code>" will be replaced with a name of a test
+            (only works when specifying links next to tests - not links to comparator tool).</li>
 
         <li>"<code>%{dynamic}</code>", where you replace <code>dynamic</code> with a name of an item specified in the
             <i>config items</i> section (specifically the name from the <i>Name of the item to find</i> field).

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-failedTestLinkLabel.html
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-failedTestLinkLabel.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        The label of the link - this text will be shown next to the failed test's name.
+    </p>
+</div>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-failedTestLinkUrl.html
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-failedTestLinkUrl.html
@@ -1,0 +1,6 @@
+<div>
+    <p>
+        Specify the base tool page here (including the custom part after the .html). For example, for comparator, it should be:<br>
+        <code>comp.html?generated-part=&custom-part=</code>
+    </p>
+</div>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-spliterator.html
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-spliterator.html
@@ -1,9 +1,9 @@
 <div>
     <p>
         You can specify a special spliterator with a regex. This spliterator will then be used to split the job name
-        and each part of the split name then can be used in the filed below (Comparator tool arguments) as a special
+        and each part of the split name then can be used in the filed below as a special
         macro and make the definition of custom arguments easier. These macros are described in the help of
-        <i>Comparator tool arguments</i> field.
+        <i>(Comparator) tool arguments</i> field.
     </p>
     <p>
         An example of this spliterator can for example be "<code>[.-]</code>", which will split the name by either a

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.report.jtreg;
 
+import io.jenkins.plugins.report.jtreg.items.LinkToComparator;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 import io.jenkins.plugins.report.jtreg.model.SuiteTestChanges;
 import io.jenkins.plugins.report.jtreg.model.SuiteTestsWithResults;


### PR DESCRIPTION
In this PR, I implemented custom settable dynamic links which will appear next to a failed test on the jtreg report page (instead of the hardcoded "track") link.

Also, `--virtual` now overrides the `--skip-failed` default to false.

Should close issues #30 and #33.