### PR TITLE
Added field for future usage of reading "latest" list

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -15,7 +15,24 @@ permissions:
   actions: read
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+      
+      - name: Build with Maven
+        run: mvn clean install
+
   security-scan:
+    needs: build
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,32 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(
-  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-  configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
-])
+
+// Custom pipeline to run mvn clean install before buildPlugin
+pipeline {
+  agent any
+  
+  stages {
+    stage('Pre-Build: Maven Clean Install') {
+      steps {
+        sh 'mvn clean install -DskipTests'
+      }
+    }
+    
+    stage('Build Plugin') {
+      steps {
+        script {
+          buildPlugin(
+            forkCount: '1C',
+            useContainerAgent: true,
+            configurations: [
+              [platform: 'linux', jdk: 21],
+              [platform: 'windows', jdk: 17],
+            ]
+          )
+        }
+      }
+    }
+  }
+}
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,27 +7,19 @@
 pipeline {
   agent any
   
+  tools {
+    jdk 'jdk21'
+    maven 'mvn'
+  }
+  
   stages {
     stage('Pre-Build: Maven Clean Install') {
       steps {
-        sh 'mvn clean install -DskipTests'
-      }
-    }
-    
-    stage('Build Plugin') {
-      steps {
-        script {
-          buildPlugin(
-            forkCount: '1C',
-            useContainerAgent: true,
-            configurations: [
-              [platform: 'linux', jdk: 21],
-              [platform: 'windows', jdk: 17],
-            ]
-          )
-        }
+        checkout scm
+        sh 'mvn clean install'
       }
     }
   }
 }
+
 

--- a/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/VirtualJobsResults.java
+++ b/report-jtreg-comparator/src/main/java/io/jenkins/plugins/report/jtreg/main/comparator/VirtualJobsResults.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.report.jtreg.main.comparator;
 
 import io.jenkins.plugins.report.jtreg.ConfigFinder;
+import io.jenkins.plugins.report.jtreg.PreviousBuilds;
 import io.jenkins.plugins.report.jtreg.formatters.Formatter;
 import io.jenkins.plugins.report.jtreg.formatters.JtregPluginServicesCell;
 import io.jenkins.plugins.report.jtreg.formatters.JtregPluginServicesLinkWithTooltip;
@@ -67,7 +68,7 @@ public class VirtualJobsResults {
 
     public static List<JtregPluginServicesLinkWithTooltip> createTooltip(String result, String buildName, String buildId, int column, String id, String url) {
         List<JtregPluginServicesLinkWithTooltip> tooltips = new ArrayList<>();
-        tooltips.add(new JtregPluginServicesLinkWithTooltip(result, url + "/job/" + buildName + "/" + buildId + "/java-reports#" + result));
+        tooltips.add(new JtregPluginServicesLinkWithTooltip(result, url + "/job/" + buildName + "/" + buildId + "/"+ PreviousBuilds.DEFAULT_ENDPOINT+"#" + result));
         tooltips.add(new JtregPluginServicesLinkWithTooltip(" * self: " + column, "#" + id));
         tooltips.add(new JtregPluginServicesLinkWithTooltip(" * header: " + column, "#legend-" + column));
         tooltips.add(new JtregPluginServicesLinkWithTooltip(" * column: " + column, "#table-" + column));

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtended.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtended.java
@@ -23,13 +23,12 @@
  */
 package io.jenkins.plugins.report.jtreg;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.report.jtreg.model.BuildReport;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 import io.jenkins.plugins.report.jtreg.model.SuiteTestChanges;
 import io.jenkins.plugins.report.jtreg.model.SuitesWithResults;
 
-import java.time.Duration;
-import java.util.Date;
 import java.util.List;
 
 
@@ -67,7 +66,12 @@ public class BuildReportExtended extends BuildReport {
     }
 
     public String getPreviousLink() {
-        return "../../" + (getBuildNumber() - 1) + "/java-reports";
+        return "../../" + (getBuildNumber() - 1) + "/" + getEndpoint();
+    }
+
+    @NonNull
+    private static String getEndpoint() {
+        return "java-reports";
     }
 
     public String getPreviousLinkName() {
@@ -75,11 +79,19 @@ public class BuildReportExtended extends BuildReport {
     }
 
     public String getNextLink() {
-        return "../../" + (getBuildNumber() + 1) + "/java-reports";
+        return "../../" + (getBuildNumber() + 1) +"/" + getEndpoint();
     }
 
     public String getNextLinkName() {
         return " >> " + (getBuildNumber() + 1) + " >> ";
+    }
+
+    public String getComparedAgainstCaption() {
+        return comparedAgainstBuildNumber + "(" + comparedAgainstBuildName + ")";
+    }
+
+    public String getCustomTitle() {
+        return this.job + ": " +  getBuildNumber() + "/" + getBuildNumber() + " compared to: " + getComparedAgainstCaption();
     }
 
     public List<String> getAddedSuites() {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtended.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtended.java
@@ -43,10 +43,15 @@ public class BuildReportExtended extends BuildReport {
     private final int notRunEx;
     private final SuitesWithResults allTests;
     protected final String job;
+    private final int comparedAgainstBuildNumber;
+    private final String comparedAgainstBuildName;
+    private final long comparedAgainstStart;
+    private final long comparedAgainstDuration;
 
 
     public BuildReportExtended(int buildNumber, String buildName, int passed, int failed, int error, List<Suite> suites,
-                               List<String> addedSuites, List<String> removedSuites, List<SuiteTestChanges> testChanges, int total, int notRun, SuitesWithResults allTests, String job, long timestamp, long duration) {
+                                List<String> addedSuites, List<String> removedSuites, List<SuiteTestChanges> testChanges, int total, int notRun, SuitesWithResults allTests,
+                                String job, long timestamp, long duration, int comparedAgainstBuildNumber, String comparedAgainstBuildName, long comparedAgainstStart, long comparedAgainstDuration) {
         super(buildNumber, buildName, passed, failed, error, suites, total, notRun, timestamp, duration);
         this.job = job;
         this.addedSuites = addedSuites;
@@ -55,6 +60,10 @@ public class BuildReportExtended extends BuildReport {
         this.totalEx = total;
         this.notRunEx = notRun;
         this.allTests = allTests;
+        this.comparedAgainstBuildNumber = comparedAgainstBuildNumber;
+        this.comparedAgainstBuildName = comparedAgainstBuildName;
+        this.comparedAgainstStart = comparedAgainstStart;
+        this.comparedAgainstDuration = comparedAgainstDuration;
     }
 
     public String getPreviousLink() {
@@ -103,4 +112,19 @@ public class BuildReportExtended extends BuildReport {
         return allTests;
     }
 
+    public String getComparedAgainstBuildName() {
+        return comparedAgainstBuildName;
+    }
+
+    public int getComparedAgainstBuildNumber() {
+        return comparedAgainstBuildNumber;
+    }
+
+    public long getComparedAgainstDuration() {
+        return comparedAgainstDuration;
+    }
+
+    public long getComparedAgainstStart() {
+        return comparedAgainstStart;
+    }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtended.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtended.java
@@ -23,7 +23,6 @@
  */
 package io.jenkins.plugins.report.jtreg;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import io.jenkins.plugins.report.jtreg.model.BuildReport;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 import io.jenkins.plugins.report.jtreg.model.SuiteTestChanges;
@@ -42,10 +41,10 @@ public class BuildReportExtended extends BuildReport {
     private final int notRunEx;
     private final SuitesWithResults allTests;
     protected final String job;
-    private final int comparedAgainstBuildNumber;
-    private final String comparedAgainstBuildName;
-    private final long comparedAgainstStart;
-    private final long comparedAgainstDuration;
+    protected final int comparedAgainstBuildNumber;
+    protected final String comparedAgainstBuildName;
+    protected final long comparedAgainstStart;
+    protected final long comparedAgainstDuration;
 
 
     public BuildReportExtended(int buildNumber, String buildName, int passed, int failed, int error, List<Suite> suites,
@@ -63,35 +62,6 @@ public class BuildReportExtended extends BuildReport {
         this.comparedAgainstBuildName = comparedAgainstBuildName;
         this.comparedAgainstStart = comparedAgainstStart;
         this.comparedAgainstDuration = comparedAgainstDuration;
-    }
-
-    public String getPreviousLink() {
-        return "../../" + (getBuildNumber() - 1) + "/" + getEndpoint();
-    }
-
-    @NonNull
-    private static String getEndpoint() {
-        return "java-reports";
-    }
-
-    public String getPreviousLinkName() {
-        return " << " + (getBuildNumber() - 1) + " << ";
-    }
-
-    public String getNextLink() {
-        return "../../" + (getBuildNumber() + 1) +"/" + getEndpoint();
-    }
-
-    public String getNextLinkName() {
-        return " >> " + (getBuildNumber() + 1) + " >> ";
-    }
-
-    public String getComparedAgainstCaption() {
-        return comparedAgainstBuildNumber + "(" + comparedAgainstBuildName + ")";
-    }
-
-    public String getCustomTitle() {
-        return this.job + ": " +  getBuildNumber() + "/" + getBuildNumber() + " compared to: " + getComparedAgainstCaption();
     }
 
     public List<String> getAddedSuites() {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedFactory.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedFactory.java
@@ -11,7 +11,8 @@ public class BuildReportExtendedFactory {
                                                          int error, List<Suite> suites, List<String> addedSuites,
                                                          List<String> removedSuites, List<SuiteTestChanges> testChanges,
                                                          int total, int notRun, SuitesWithResults allTests,
-                                                         String job, long timestamp, long duration) {
-        return new BuildReportExtended(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites, testChanges, total, notRun, allTests, job, timestamp, duration);
+                                                         String job, long timestamp, long duration,
+                                                         int comparedAgainstBuildNumber, String comparedAgainstBuildName, long comparedAgainstStart, long comparedAgainstDuration) {
+        return new BuildReportExtended(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites, testChanges, total, notRun, allTests, job, timestamp, duration, comparedAgainstBuildNumber, comparedAgainstBuildName, comparedAgainstStart, comparedAgainstDuration);
     }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParser.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParser.java
@@ -245,7 +245,11 @@ public class BuildSummaryParser {
                 currentReport.getTotal(),
                 currentReport.getNotRun(),
                 allTests,
-                job, currentReport.getTimestamp(), currentReport.getDuration());
+                job, currentReport.getTimestamp(), currentReport.getDuration(),
+                previousPassedOrUnstable == null ? -1:previousPassedOrUnstable.getNumber(),
+                previousPassedOrUnstable == null ? null:previousPassedOrUnstable.getName(),
+                previousPassedOrUnstable == null ? -1:previousPassedOrUnstable.getTimestamp(),
+                previousPassedOrUnstable == null ? -1:previousPassedOrUnstable.getDuration());
     }
 
     protected List<Suite> parseBuildSummary(File rootDir) throws Exception {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
@@ -40,8 +40,8 @@ final public class Constants {
             "report-problems.txt",
             getReportDiffTxt(""),
             "report-all-tests.txt",
-            getReportDiff(PreviousBuilds.EXACT),
-            getReportDiffTxt(PreviousBuilds.EXACT)
+            getReportDiff(PreviousBuilds.EXACT_SUFFIX),
+            getReportDiffTxt(PreviousBuilds.EXACT_SUFFIX)
     ));
     public static final String REPORT_JSON = prefixedFiles.get(0);
     public static final String REPORT_TESTS_LIST_JSON = prefixedFiles.get(1);
@@ -59,7 +59,7 @@ final public class Constants {
 
     public static final String REPORT_ALL_TESTS_TXT = prefixedFiles.get(6);
 
-    public static final List<String> unprefixedFiles = Collections.unmodifiableList(Arrays.asList("cached-summ-results.properties", getCachedSummRegressionsProperties(""), getCachedSummRegressionsProperties(PreviousBuilds.EXACT)));
+    public static final List<String> unprefixedFiles = Collections.unmodifiableList(Arrays.asList("cached-summ-results.properties", getCachedSummRegressionsProperties(""), getCachedSummRegressionsProperties(PreviousBuilds.EXACT_SUFFIX)));
     public static final String CACHED_SUMM_RESULTS_PROPERTIES = unprefixedFiles.get(0);
 
     public static String getCachedSummRegressionsProperties(String suffix) {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/Constants.java
@@ -35,26 +35,36 @@ final public class Constants {
     public static final List<String> prefixedFiles = Collections.unmodifiableList(Arrays.asList(
             "report.json",
             "tests-list.json",
-            "jr-diff.json",
+            getReportDiff(""),
             "report-summary.txt",
             "report-problems.txt",
-            "report-diff.txt",
-            "report-all-tests.txt"
+            getReportDiffTxt(""),
+            "report-all-tests.txt",
+            getReportDiff(PreviousBuilds.EXACT),
+            getReportDiffTxt(PreviousBuilds.EXACT)
     ));
     public static final String REPORT_JSON = prefixedFiles.get(0);
     public static final String REPORT_TESTS_LIST_JSON = prefixedFiles.get(1);
-    public static final String REPORT_DIFF = prefixedFiles.get(2);
+
+    public static String getReportDiff(String suffix) {
+        return "jr-diff" + suffix + ".json";
+    }
+
     public static final String REPORT_SUMMARY_TXT = prefixedFiles.get(3);
     public static final String REPORT_PROBLEMS_TXT = prefixedFiles.get(4);
-    public static final String REPORT_DIFF_TXT = prefixedFiles.get(5);
+
+    public static String getReportDiffTxt(String suffix) {
+        return "report-diff" + suffix + ".txt";
+    }
+
     public static final String REPORT_ALL_TESTS_TXT = prefixedFiles.get(6);
 
-    public static final List<String> unprefixedFiles = Collections.unmodifiableList(Arrays.asList(
-            "cached-summ-results.properties",
-            "cached-summ-regressions.properties"
-    ));
-    public static final String CACHED_SUMM_RESULTS_PROPERTIES =  unprefixedFiles.get(0);
-    public static final String CACHED_SUMM_REGRESSIONS_PROPERTIES = unprefixedFiles.get(1);
+    public static final List<String> unprefixedFiles = Collections.unmodifiableList(Arrays.asList("cached-summ-results.properties", getCachedSummRegressionsProperties(""), getCachedSummRegressionsProperties(PreviousBuilds.EXACT)));
+    public static final String CACHED_SUMM_RESULTS_PROPERTIES = unprefixedFiles.get(0);
+
+    public static String getCachedSummRegressionsProperties(String suffix) {
+        return "cached-summ-regressions" + suffix + ".properties";
+    }
 
 
     public static final String IRRELEVANT_GLOB_STRING = "report-{runtime,devtools,compiler}.xml.gz";

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/PreviousBuilds.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/PreviousBuilds.java
@@ -5,7 +5,11 @@ import java.util.function.Predicate;
 
 public class PreviousBuilds {
 
-    public static final String EXACT = "-exact";
+    public static final String DEFAULT_ENDPOINT = "java-reports";
+    public static final String EXACT = "exact";
+    public static final String EXACT_SUFFIX = "-" + EXACT;
+    public static final String EXACT_PREFIX = EXACT + "-";
+    public static final String SECOND_ENDPOINT = EXACT_PREFIX + DEFAULT_ENDPOINT;
 
     public static Predicate<String> getAllPredicate() {
         return s -> true;
@@ -49,8 +53,11 @@ public class PreviousBuilds {
     }
 
     public String[] getSuffixes() {
-        return new String[]{"", EXACT};
+        return new String[]{"", EXACT_SUFFIX};
     }
 
 
+    public String[] getEndpoints() {
+        return new String[]{DEFAULT_ENDPOINT, SECOND_ENDPOINT};
+    }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/PreviousBuilds.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/PreviousBuilds.java
@@ -1,0 +1,56 @@
+package io.jenkins.plugins.report.jtreg;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public class PreviousBuilds {
+
+    public static final String EXACT = "-exact";
+
+    public static Predicate<String> getAllPredicate() {
+        return s -> true;
+    }
+
+    public static Predicate<String> createPredicate(List<String> displayNamesToFind) {
+        return new Predicate<String>() {
+            @Override
+            public boolean test(String s) {
+                return displayNamesToFind.contains(s);
+            }
+        };
+    }
+
+    public static Predicate<String> createPredicate() {
+        return createPredicate(SecondComparison.getInstance().getList());
+    }
+
+    private final BuildReportExtended lastStableUnstableBuild;
+    private final BuildReportExtended lastNamedStableUnstableBuild;
+
+    public PreviousBuilds(BuildReportExtended lastStableUnstableBuild, BuildReportExtended lastNamedStableUnstableBuild) {
+        this.lastStableUnstableBuild = lastStableUnstableBuild;
+        this.lastNamedStableUnstableBuild = lastNamedStableUnstableBuild;
+    }
+
+    public BuildReportExtended getLastNamedStableUnstableBuild() {
+        return lastNamedStableUnstableBuild;
+    }
+
+    public BuildReportExtended getLastStableUnstableBuild() {
+        return lastStableUnstableBuild;
+    }
+
+    public BuildReportExtended[] getBuilds() {
+        return new BuildReportExtended[]{lastStableUnstableBuild, lastNamedStableUnstableBuild};
+    }
+
+    public String[] getResolutions() {
+        return new String[]{"latest stable or unstable", "exact, specified (released, latest stable...) build"};
+    }
+
+    public String[] getSuffixes() {
+        return new String[]{"", EXACT};
+    }
+
+
+}

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/SecondComparison.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/SecondComparison.java
@@ -1,0 +1,100 @@
+package io.jenkins.plugins.report.jtreg;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class SecondComparison {
+
+    public interface SecondComparisonUrlProvider {
+        String getSecondComparisonUrl();
+    }
+
+
+    private static SecondComparison instance;
+    private final SecondComparisonUrlProvider provider;
+    private List<String> cache = new ArrayList<>();
+    private Date cachedAt = new Date(0);
+    private static final long CACHE_TIMEOUT = 60 * 60 * 1000;
+
+    SecondComparison(SecondComparisonUrlProvider provider) {
+        if (provider == null) {
+            throw new IllegalArgumentException("provider must not be null");
+        }
+        this.provider = provider;
+    }
+
+    public static synchronized SecondComparison getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("SecondComparison has not yet been initialized");
+        }
+        return instance;
+    }
+
+    public static synchronized SecondComparison getOrCreateInstance(SecondComparisonUrlProvider provider) {
+        //the provider returning null ro empty is ok, it is causing the instance to be practically disabled
+        //it is also expected that the provider behavior can change in time
+        if (instance == null) {
+            instance = new SecondComparison(provider);
+        }
+        return instance;
+    }
+
+    public synchronized List<String> getList() {
+        if (isReadingCurrentlyAllowed()) {
+            if (shouldRefresh()) {
+                cache = read();
+                cachedAt = new Date();
+                if (cache.isEmpty()) {
+                    cache = null;
+                }
+                return cache;
+            } else {
+                return cache;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    private boolean isReadingCurrentlyAllowed() {
+        return provider.getSecondComparisonUrl() != null && !provider.getSecondComparisonUrl().isBlank();
+    }
+
+    private boolean shouldRefresh() {
+        return new Date().getTime() > (cachedAt.getTime() + CACHE_TIMEOUT);
+    }
+
+    private  List<String> read() {
+        return readImpl(provider.getSecondComparisonUrl());
+    }
+
+    private static List<String> readImpl(String surl) {
+        try {
+            URL url = new URL(surl);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
+                return reader.lines().filter(s -> !s.isBlank()).map(s->s.trim()).collect(Collectors.toList());
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            return null;
+        }
+    }
+
+    public static Predicate<String> createPredicate(List<String> displayNamesToFind) {
+        return new  Predicate<String>() {
+            @Override
+            public boolean test(String s) {
+                return displayNamesToFind.contains(s);
+            }
+        };
+    }
+
+
+}

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/SecondComparison.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/SecondComparison.java
@@ -87,14 +87,7 @@ public class SecondComparison {
         }
     }
 
-    public static Predicate<String> createPredicate(List<String> displayNamesToFind) {
-        return new  Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return displayNamesToFind.contains(s);
-            }
-        };
-    }
+
 
 
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/SecondComparison.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/SecondComparison.java
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class SecondComparison {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/formatters/HtmlFormatter.java
@@ -29,6 +29,7 @@ import com.github.difflib.patch.Patch;
 import com.github.difflib.text.DiffRow;
 import com.github.difflib.text.DiffRowGenerator;
 import io.jenkins.plugins.report.jtreg.Constants;
+import io.jenkins.plugins.report.jtreg.PreviousBuilds;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -213,7 +214,7 @@ public class HtmlFormatter extends StringMappedFormatter {
         String mainLine =
                 "<a class='NameBuildLine' href='" + urlStub + "/job/" + jobName + "'>"
                         + jobName + "</a>" + " - " + "<a class='NameBuildLine' href='" + urlStub + "/job/" + jobName + "/" + buildId + "'>build</a>"
-                        + ":" + "<a class='NameBuildLine' href='" + urlStub + "/job/" + jobName + "/" + buildId + "/java-reports'>" + buildId +
+                        + ":" + "<a class='NameBuildLine' href='" + urlStub + "/job/" + jobName + "/" + buildId + "/" + PreviousBuilds.DEFAULT_ENDPOINT + "'>" + buildId +
                         "</a>";
         headerItem.append("<span class='NameBuildLineWrap'>").append(mainLine).append("</span><br>");
         // other lines, hidden by default

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/model/ProjectReport.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/model/ProjectReport.java
@@ -30,11 +30,15 @@ public class ProjectReport implements java.io.Serializable {
     private final List<? extends  BuildReport> reports;
     private final List<Integer> improvements;
     private final List<Integer> regressions;
+    private final List<Integer> secondaryImprovements;
+    private final List<Integer> secondaryRegressions;
 
-    public ProjectReport(List<? extends BuildReport> reports, List<Integer> improvements, List<Integer> regressions) {
+    public ProjectReport(List<? extends BuildReport> reports, List<Integer> improvements, List<Integer> regressions, List<Integer> secondaryImprovements, List<Integer> secondaryRegressions) {
         this.reports = reports;
         this.improvements = improvements;
         this.regressions = regressions;
+        this.secondaryImprovements = secondaryImprovements;
+        this.secondaryRegressions = secondaryRegressions;
     }
 
     public List<? extends BuildReport> getReports() {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/model/ProjectReport.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/model/ProjectReport.java
@@ -25,6 +25,8 @@ package io.jenkins.plugins.report.jtreg.model;
 
 import java.util.List;
 
+import io.jenkins.plugins.report.jtreg.wrappers.RunWrapper;
+
 public class ProjectReport implements java.io.Serializable {
 
     private final List<? extends  BuildReport> reports;
@@ -32,13 +34,19 @@ public class ProjectReport implements java.io.Serializable {
     private final List<Integer> regressions;
     private final List<Integer> secondaryImprovements;
     private final List<Integer> secondaryRegressions;
+    private final String found;
 
-    public ProjectReport(List<? extends BuildReport> reports, List<Integer> improvements, List<Integer> regressions, List<Integer> secondaryImprovements, List<Integer> secondaryRegressions) {
+    public ProjectReport(List<? extends BuildReport> reports, List<Integer> improvements, List<Integer> regressions, List<Integer> secondaryImprovements, List<Integer> secondaryRegressions, RunWrapper found) {
         this.reports = reports;
         this.improvements = improvements;
         this.regressions = regressions;
         this.secondaryImprovements = secondaryImprovements;
         this.secondaryRegressions = secondaryRegressions;
+        if (found == null) {
+            this.found =  "not set/not found";
+        } else {
+            this.found =  found.getName() + "/" + found.getNumber();
+        }
     }
 
     public List<? extends BuildReport> getReports() {
@@ -53,4 +61,15 @@ public class ProjectReport implements java.io.Serializable {
         return regressions;
     }
 
+    public List<Integer> getSecondaryImprovements() {
+        return secondaryImprovements;
+    }
+
+    public List<Integer> getSecondaryRegressions() {
+        return secondaryRegressions;
+    }
+
+    public String getFound() {
+        return found;
+    }
 }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/RecreateArgs.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/RecreateArgs.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import io.jenkins.plugins.report.jtreg.SecondComparison;
 import io.jenkins.plugins.report.jtreg.writers.WriterKinds;
 
 public class RecreateArgs implements ExportArgs{
@@ -29,7 +30,10 @@ public class RecreateArgs implements ExportArgs{
             System.out.println("               PLAIN will regenerate plaintexts, JSON jsons and PROPERTIES properties. Default is JSON,PLAIN,PROPERTIES");
             System.out.println("               You can not regenerate PLAIN or PROPERTIES without jsons already in place");
             System.out.println("               Everything is always backup-ed and exported. This is really about what is regenerated");
-            System.out.println("               Special value is NONE, which willc ause to regenerate nothing, and just export (if set)");
+            System.out.println("               Special value is NONE, which will cause to regenerate nothing, and just export (if set)");
+            System.out.println("-compare-to <url> including file://");
+            System.out.println("               Url to plaintext file, with one displayName per line. If presented, the each build is compared als against *first found* from this list ");
+            System.out.println("-max-past <int> how deep to history the exact NVRS shoudl eb searched. Default is 100");
             System.out.println("                                                                               ");
             System.out.println("Because regeneration regenerates also the jsons, which are crucial to the operation of plugin, the export works like this:");
             System.out.println("      the backup is done");
@@ -54,6 +58,20 @@ public class RecreateArgs implements ExportArgs{
             return true;
         }
         return false;
+    }
+
+    public void initCommandlineSecondComparison() {
+        final String url =  get("-compare-to");
+        SecondComparison.getOrCreateInstance(() -> url);
+    }
+
+    public int getMaxPastForSecondCOmparison() {
+        final String maxs =  get("-max-past");
+        if (maxs == null) {
+            return 100;
+        } else {
+            return Integer.parseInt(maxs);
+        }
     }
 
     public String getUrl() {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
@@ -111,7 +111,13 @@ public class ReportSummaryUtil {
             if (oldDir.exists()) {
                 String resultOld = ConfigFinder.findInConfigStatic(new File(oldDir, "build.xml"), "result", "/build/result");
                 if (SUCCESS_DUPLICATE.equals(resultOld) || UNSTABLE_DUPLICATE.equals(resultOld)) {
-                    found = new RunWrapperFromDir(oldDir);
+                    String displayName = ConfigFinder.findInConfigStatic(new File(oldDir, "build.xml"), "nvr", "/build/displayName");
+                    if (displayName == null) {
+                        displayName = "#"+i;
+                    }
+                    long timeStamp = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "timestamp", "/build/timestamp"));
+                    long duration = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "duration", "/build/duration"));
+                    found = new RunWrapperFromDirWithName(oldDir, timeStamp, duration, displayName);
                     break;
                 }
             }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
@@ -132,12 +132,12 @@ public class ReportSummaryUtil {
 
     public static RunWrapper findPreviousBuild(Path buildPath, int jobId, Predicate<String> displayNamePredicate, int secondaryCounter) {
         for (int i = jobId - 1; i > 0; i--) {
-            secondaryCounter--;
-            if (secondaryCounter < 0) {
-                return null;
-            }
             File oldDir = new File(buildPath.toFile().getParentFile(), "" + i);
             if (oldDir.exists()) {
+                secondaryCounter--;
+                if (secondaryCounter < 0) {
+                    return null;
+                }
                 String resultOld = ConfigFinder.findInConfigStatic(new File(oldDir, "build.xml"), "result", "/build/result");
                 if (SUCCESS_DUPLICATE.equals(resultOld) || UNSTABLE_DUPLICATE.equals(resultOld)) {
                     RunWrapper found = createRunWrapper(buildPath, oldDir, i, displayNamePredicate);
@@ -156,8 +156,16 @@ public class ReportSummaryUtil {
             displayName = "#"+ i;
         }
         if (displayNamePredicate.test(displayName)) {
-            long timeStamp = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "timestamp", "/build/timestamp"));
-            long duration = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "duration", "/build/duration"));
+            long timeStamp = -1;
+            try {
+                timeStamp = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "timestamp", "/build/timestamp"));
+            }catch (Exception ex) {
+            }
+            long duration = -1 ;
+            try {
+                duration = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "duration", "/build/duration"));
+            } catch ( Exception ex) {
+            }
             RunWrapper found = new RunWrapperFromDirWithName(oldDir, timeStamp, duration, displayName);
             return found;
         } else {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
@@ -130,7 +130,7 @@ public class ReportSummaryUtil {
         }
     }
 
-    private static RunWrapper findPreviousBuild(Path buildPath, int jobId, Predicate<String> displayNamePredicate, int secondaryCounter) {
+    public static RunWrapper findPreviousBuild(Path buildPath, int jobId, Predicate<String> displayNamePredicate, int secondaryCounter) {
         for (int i = jobId - 1; i > 0; i--) {
             secondaryCounter--;
             if (secondaryCounter < 0) {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.plugins.report.jtreg.BuildReportExtended;
 import io.jenkins.plugins.report.jtreg.BuildSummaryParser;
 import io.jenkins.plugins.report.jtreg.ConfigFinder;
+import io.jenkins.plugins.report.jtreg.PreviousBuilds;
 import io.jenkins.plugins.report.jtreg.SecondComparison;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 import io.jenkins.plugins.report.jtreg.wrappers.RunWrapper;
@@ -89,22 +90,26 @@ public class ReportSummaryUtil {
         BuildReportExtended br1 = getReportAgainstPreviousBuild(prefix, buildPath, jobId, displayName);
         BuildReportExtended br2 = getReportAgainstExactBuild(prefix, buildPath, jobId, displayName, params.getMaxPastForSecondCOmparison());
         // write diff with all metadata
-        WritersManager.storeAllDiffs(prefix, br1, buildPath.toFile(), params.getUrl(), params.getKinds());
+        WritersManager.storeAllDiffs(prefix, new PreviousBuilds(br1, br2), buildPath.toFile(), params.getUrl(), params.getKinds());
         export(prefix, buildPath, params, zipPath, displayName, br1, jobId, null);
 
 
     }
 
     private static BuildReportExtended getReportAgainstPreviousBuild(String prefix, Path buildPath, int jobId, String displayName) throws Exception {
-        RunWrapper found = findPreviousBuild(buildPath, jobId, s -> true, Integer.MAX_VALUE);
+        RunWrapper found = findPreviousBuild(buildPath, jobId, PreviousBuilds.getAllPredicate(), Integer.MAX_VALUE);
         return getReportAgaisntFoundBuild(prefix, buildPath, displayName, found);
     }
 
     private static BuildReportExtended getReportAgainstExactBuild(String prefix, Path buildPath, int jobId, String displayName, int pastToSeakTo) throws Exception {
         List<String> displayNamesToFind = SecondComparison.getInstance().getList();
         if (displayNamesToFind != null) {
-            RunWrapper found = findPreviousBuild(buildPath, jobId, SecondComparison.createPredicate(displayNamesToFind), pastToSeakTo);
-            return getReportAgaisntFoundBuild(prefix, buildPath, displayName, found);
+            RunWrapper found = findPreviousBuild(buildPath, jobId, PreviousBuilds.createPredicate(displayNamesToFind), pastToSeakTo);
+            if (found != null) {
+                return getReportAgaisntFoundBuild(prefix, buildPath, displayName, found);
+            } else {
+                return null;
+            }
         } else {
             return null;
         }

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/recreate/ReportSummaryUtil.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.plugins.report.jtreg.BuildReportExtended;
 import io.jenkins.plugins.report.jtreg.BuildSummaryParser;
 import io.jenkins.plugins.report.jtreg.ConfigFinder;
+import io.jenkins.plugins.report.jtreg.SecondComparison;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 import io.jenkins.plugins.report.jtreg.wrappers.RunWrapper;
 import io.jenkins.plugins.report.jtreg.wrappers.RunWrapperFromDir;
@@ -44,6 +45,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -84,16 +86,36 @@ public class ReportSummaryUtil {
         String displayName = getDisplayName(buildPath, jobId);
         // write static files
         WritersManager.storeAllSummaries(prefix, suitesList, buildPath.toFile(), displayName, params.getUrl(), params.getKinds());
-        RunWrapper found = findPreviousBuild(buildPath, jobId);
+        BuildReportExtended br1 = getReportAgainstPreviousBuild(prefix, buildPath, jobId, displayName);
+        BuildReportExtended br2 = getReportAgainstExactBuild(prefix, buildPath, jobId, displayName, params.getMaxPastForSecondCOmparison());
+        // write diff with all metadata
+        WritersManager.storeAllDiffs(prefix, br1, buildPath.toFile(), params.getUrl(), params.getKinds());
+        export(prefix, buildPath, params, zipPath, displayName, br1, jobId, null);
+
+
+    }
+
+    private static BuildReportExtended getReportAgainstPreviousBuild(String prefix, Path buildPath, int jobId, String displayName) throws Exception {
+        RunWrapper found = findPreviousBuild(buildPath, jobId, s -> true, Integer.MAX_VALUE);
+        return getReportAgaisntFoundBuild(prefix, buildPath, displayName, found);
+    }
+
+    private static BuildReportExtended getReportAgainstExactBuild(String prefix, Path buildPath, int jobId, String displayName, int pastToSeakTo) throws Exception {
+        List<String> displayNamesToFind = SecondComparison.getInstance().getList();
+        if (displayNamesToFind != null) {
+            RunWrapper found = findPreviousBuild(buildPath, jobId, SecondComparison.createPredicate(displayNamesToFind), pastToSeakTo);
+            return getReportAgaisntFoundBuild(prefix, buildPath, displayName, found);
+        } else {
+            return null;
+        }
+    }
+
+    private static BuildReportExtended getReportAgaisntFoundBuild(String prefix, Path buildPath, String displayName, RunWrapper found) throws Exception {
         long timeStamp = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "timestamp", "/build/timestamp"));
         //warning, duration will change (to better), that is correct
         long duration = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "duration", "/build/duration"));
         BuildReportExtended br = new BuildSummaryParser(Arrays.asList(prefix), null/*?*/).parseBuildReportExtended(new RunWrapperFromDirWithName(buildPath.toFile(), timeStamp, duration, displayName), found);
-        // write diff with all metadata
-        WritersManager.storeAllDiffs(prefix, br, buildPath.toFile(), params.getUrl(), params.getKinds());
-        export(prefix, buildPath, params, zipPath, displayName, br, jobId, null);
-
-
+        return br;
     }
 
     private static void checkResultOfCurrentBuild(Path buildPath) {
@@ -103,26 +125,39 @@ public class ReportSummaryUtil {
         }
     }
 
-    private static RunWrapper findPreviousBuild(Path buildPath, int jobId) {
-        //find previous build (if any)
-        RunWrapper found = null;
+    private static RunWrapper findPreviousBuild(Path buildPath, int jobId, Predicate<String> displayNamePredicate, int secondaryCounter) {
         for (int i = jobId - 1; i > 0; i--) {
+            secondaryCounter--;
+            if (secondaryCounter < 0) {
+                return null;
+            }
             File oldDir = new File(buildPath.toFile().getParentFile(), "" + i);
             if (oldDir.exists()) {
                 String resultOld = ConfigFinder.findInConfigStatic(new File(oldDir, "build.xml"), "result", "/build/result");
                 if (SUCCESS_DUPLICATE.equals(resultOld) || UNSTABLE_DUPLICATE.equals(resultOld)) {
-                    String displayName = ConfigFinder.findInConfigStatic(new File(oldDir, "build.xml"), "nvr", "/build/displayName");
-                    if (displayName == null) {
-                        displayName = "#"+i;
+                    RunWrapper found = createRunWrapper(buildPath, oldDir, i, displayNamePredicate);
+                    if (found != null) {
+                        return found;
                     }
-                    long timeStamp = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "timestamp", "/build/timestamp"));
-                    long duration = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "duration", "/build/duration"));
-                    found = new RunWrapperFromDirWithName(oldDir, timeStamp, duration, displayName);
-                    break;
                 }
             }
         }
-        return found;
+        return null;
+    }
+
+    private static RunWrapper createRunWrapper(Path buildPath, File oldDir, int i, Predicate<String> displayNamePredicate) {
+        String displayName = ConfigFinder.findInConfigStatic(new File(oldDir, "build.xml"), "nvr", "/build/displayName");
+        if (displayName == null) {
+            displayName = "#"+ i;
+        }
+        if (displayNamePredicate.test(displayName)) {
+            long timeStamp = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "timestamp", "/build/timestamp"));
+            long duration = Long.parseLong(ConfigFinder.findInConfigStatic(new File(buildPath.toFile(), "build.xml"), "duration", "/build/duration"));
+            RunWrapper found = new RunWrapperFromDirWithName(oldDir, timeStamp, duration, displayName);
+            return found;
+        } else {
+            return null;
+        }
     }
 
     private static String getDisplayName(Path buildPath, int jobId) {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PlainTextWriter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PlainTextWriter.java
@@ -27,7 +27,6 @@ import io.jenkins.plugins.report.jtreg.BuildReportExtended;
 import io.jenkins.plugins.report.jtreg.model.ReportFull;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 import io.jenkins.plugins.report.jtreg.model.SuiteTestChanges;
-import io.jenkins.plugins.report.jtreg.model.SuiteTests;
 import io.jenkins.plugins.report.jtreg.model.SuitesWithResults;
 import io.jenkins.plugins.report.jtreg.model.Test;
 import io.jenkins.plugins.report.jtreg.model.TestOutput;
@@ -249,7 +248,7 @@ public class PlainTextWriter {
      * @param outputPath the output file path
      * @throws IOException if an I/O error occurs
      */
-    public static void writeDiffReport(BuildReportExtended buildReportExtended, Path outputPath, String url) throws IOException {
+    public static void writeDiffReport(BuildReportExtended buildReportExtended, Path outputPath, String url, String resolution) throws IOException {
 
         // Calculate totals
         int totalImprovements = 0;
@@ -271,7 +270,7 @@ public class PlainTextWriter {
             // Write header
             writeHeader(writer, buildReportExtended.getJob(), buildReportExtended.getBuildName(), buildReportExtended.getBuildNumber(), url, buildReportExtended.getTimestamp(), buildReportExtended.getDuration());
 
-            writer.write("This report shows changes compared to the previous, latest stable or unstable, build.\n\n");
+            writer.write("This report shows changes compared to the previous, " + resolution + ", build "+getPreviousBuild(buildReportExtended)+".\n\n");
             
             // Write summary
             writer.write("Summary of Changes:\n");
@@ -372,10 +371,14 @@ public class PlainTextWriter {
                 totalAdded == 0 && totalRemoved == 0 && 
                 buildReportExtended.getAddedSuites().isEmpty() && 
                 buildReportExtended.getRemovedSuites().isEmpty()) {
-                writer.write("No changes detected compared to the previous, latest stable or unstable, build.\n");
+                writer.write("No changes detected compared to the previous, " + resolution + ", build "+getPreviousBuild(buildReportExtended)+".\n");
             }
             footer(writer, buildReportExtended.getJob(), buildReportExtended.getBuildName(), buildReportExtended.getBuildNumber(), url, "detailed diff report", buildReportExtended.getDateIso());
         }
+    }
+
+    static String getPreviousBuild(BuildReportExtended br) {
+        return PropertiesWriter.getPreviousBuildName(br) + "(" + PropertiesWriter.getPreviousBuildNumber(br) + "), which started at " + toKnown(br.getComparedAgainstStart(), true, false) + " and had duration of " + toKnown(br.getComparedAgainstDuration(), true, true);
     }
 
     /**
@@ -448,7 +451,7 @@ public class PlainTextWriter {
     }
 
 
-    private static String toKnown(long time, boolean port, boolean duration) {
+    static String toKnown(long time, boolean port, boolean duration) {
         if (time <= 0) {
             return "unknown";
         } else {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PlainTextWriter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PlainTextWriter.java
@@ -24,6 +24,7 @@
 package io.jenkins.plugins.report.jtreg.writers;
 
 import io.jenkins.plugins.report.jtreg.BuildReportExtended;
+import io.jenkins.plugins.report.jtreg.PreviousBuilds;
 import io.jenkins.plugins.report.jtreg.model.ReportFull;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 import io.jenkins.plugins.report.jtreg.model.SuiteTestChanges;
@@ -159,7 +160,7 @@ public class PlainTextWriter {
                                           suite.getReport().getTestsError(),
                                           suite.getReport().getTestsNotRun()));
             }
-            footer(writer, jobName, buildName, buildNumber, url, "summary report", "unknown");
+            footer(writer, jobName, buildName, buildNumber, url, PreviousBuilds.DEFAULT_ENDPOINT, "summary report", "unknown");
         }
     }
 
@@ -236,7 +237,7 @@ public class PlainTextWriter {
             if (failedTests == 0 && errorTests == 0) {
                 writer.write("No failed or errored tests to report. All tests passed successfully!\n");
             }
-            footer(writer, jobName, buildName, buildNumber, url, "failures report", "unknown");
+            footer(writer, jobName, buildName, buildNumber, url, PreviousBuilds.DEFAULT_ENDPOINT, "failures report", "unknown");
         }
     }
 
@@ -248,7 +249,7 @@ public class PlainTextWriter {
      * @param outputPath the output file path
      * @throws IOException if an I/O error occurs
      */
-    public static void writeDiffReport(BuildReportExtended buildReportExtended, Path outputPath, String url, String resolution) throws IOException {
+    public static void writeDiffReport(BuildReportExtended buildReportExtended, Path outputPath, String url, String endpoint, String resolution) throws IOException {
 
         // Calculate totals
         int totalImprovements = 0;
@@ -373,7 +374,7 @@ public class PlainTextWriter {
                 buildReportExtended.getRemovedSuites().isEmpty()) {
                 writer.write("No changes detected compared to the previous, " + resolution + ", build "+getPreviousBuild(buildReportExtended)+".\n");
             }
-            footer(writer, buildReportExtended.getJob(), buildReportExtended.getBuildName(), buildReportExtended.getBuildNumber(), url, "detailed diff report", buildReportExtended.getDateIso());
+            footer(writer, buildReportExtended.getJob(), buildReportExtended.getBuildName(), buildReportExtended.getBuildNumber(), url, endpoint, "detailed diff report", buildReportExtended.getDateIso());
         }
     }
 
@@ -418,7 +419,7 @@ public class PlainTextWriter {
 
                     writer.write("\n");
                 }
-            footer(writer, jobName, buildName, buildNumber, url, "complete test listing", "unknown");
+            footer(writer, jobName, buildName, buildNumber, url, PreviousBuilds.DEFAULT_ENDPOINT, "complete test listing", "unknown");
         }
     }
 
@@ -467,7 +468,7 @@ public class PlainTextWriter {
         }
     }
 
-    private static void footer(BufferedWriter writer, String jobName, String buildName, int buildNumber, String url, String testType, String date) throws IOException {
+    private static void footer(BufferedWriter writer, String jobName, String buildName, int buildNumber, String url, String endpoint, String testType, String date) throws IOException {
         if (url != null) {
             writer.write("=".repeat(80) + "\n\n");
             String page = url + "/job/" + jobName;
@@ -477,7 +478,7 @@ public class PlainTextWriter {
             writer.write("You can see the build artifacts at: " + build + "/artifact" + "\n");
             writer.write("You can see the build log at: " + build + "/console" + "\n");
             writer.write("You can see the build full log at: " + build + "/consoleFull" + "\n");
-            String java = build + "/java-reports";
+            String java = build + "/" + endpoint;
             writer.write("You can see the report: " + java + "\n");
             writer.write("You can see the report's problems: " + java + "#problems\n");
             writer.write("You can see the report's diff: " + java + "#diff\n");

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PropertiesWriter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PropertiesWriter.java
@@ -137,8 +137,29 @@ public class PropertiesWriter {
             bw.newLine();
             bw.write("jrp.durationNice=" + br.getDurationIso());
             bw.newLine();
+            bw.write("jrp.comparedAgainstBuildNumber=" + getPreviousBuildNumber(br));
+            bw.newLine();
+            bw.write("jrp.comparedAgainstDisplayName=" + getPreviousBuildName(br));
+            bw.newLine();
+            bw.write("jrp.comparedAgainstTimestamp=" + PlainTextWriter.toKnown(br.getComparedAgainstStart(), false, false));
+            bw.newLine();
+            bw.write("jrp.comparedAgainstDuration=" + PlainTextWriter.toKnown(br.getComparedAgainstDuration(), false, true));
+            bw.newLine();
+            bw.write("jrp.comparedAgainstTimestampNice=" + PlainTextWriter.toKnown(br.getComparedAgainstStart(), true, false));
+            bw.newLine();
+            bw.write("jrp.comparedAgainstDurationNice=" + PlainTextWriter.toKnown(br.getComparedAgainstDuration(), true, true));
+            bw.newLine();
         }
     }
+
+    static String getPreviousBuildName(BuildReportExtended br) {
+        return br.getComparedAgainstBuildName() != null ? br.getComparedAgainstBuildName() : "unknown";
+    }
+
+    static String getPreviousBuildNumber(BuildReportExtended br) {
+        return br.getComparedAgainstBuildNumber() > 0 ? "" + br.getComparedAgainstBuildNumber() : "unknown";
+    }
+
 
     private static int allImprovements(List<SuiteTestChanges> testChanges) {
         int i = 0;

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PropertiesWriter.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/PropertiesWriter.java
@@ -62,13 +62,13 @@ public class PropertiesWriter {
     /**
      * Caches project report totals (results and regressions) to properties files.
      *
-     * @param rootBuild the root build directory
+     * @param rootBuild           the root build directory
      * @param buildReportExtended the project report to cache
      */
-    public static void writeReportPropertiesRegressions(File rootBuild, BuildReportExtended buildReportExtended) {
+    public static void writeReportPropertiesRegressions(File rootBuild, BuildReportExtended buildReportExtended, String suffix) {
         try {
             File buildParent = rootBuild.getParentFile().getParentFile();
-            File cachedRegressions = getCachedRegressionsFile(buildParent, buildReportExtended.getBuildNumber());
+            File cachedRegressions = getCachedRegressionsFile(buildParent, buildReportExtended.getBuildNumber(), suffix);
             cacheRegressionsImpl(cachedRegressions, buildReportExtended);
         } catch (IOException ex) {
             ex.printStackTrace();
@@ -229,8 +229,8 @@ public class PropertiesWriter {
         }
     }
 
-    private static File getCachedRegressionsFile(File rootBuild, int buildNumber) {
-        return getCachedFile(rootBuild, buildNumber, Constants.CACHED_SUMM_REGRESSIONS_PROPERTIES);
+    private static File getCachedRegressionsFile(File rootBuild, int buildNumber, String suffix) {
+        return getCachedFile(rootBuild, buildNumber, Constants.getCachedSummRegressionsProperties(suffix));
     }
 
     private static File getCachedResultsFile(File rootBuild, int buildNumber) {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/WritersManager.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/WritersManager.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import io.jenkins.plugins.report.jtreg.BuildReportExtended;
 import io.jenkins.plugins.report.jtreg.Constants;
+import io.jenkins.plugins.report.jtreg.PreviousBuilds;
 import io.jenkins.plugins.report.jtreg.model.Suite;
 
 public class WritersManager {
@@ -52,17 +53,22 @@ public class WritersManager {
 
 
     //Note, that this diff is not, and should not be, used in comparison - that should remain dynamic
-    public static void storeAllDiffs(String prefix, BuildReportExtended buildReportExtended, File rootDir, String url, List<WriterKinds> kinds) throws IOException {
-        buildReportExtended = purify(buildReportExtended);
-        if (allOrSet(kinds, WriterKinds.JSON)) {
-            File diffJson = new File(rootDir, prefix + "-" + Constants.REPORT_DIFF);
-            JsonReportWriter.writeBuildReportExtended(diffJson, buildReportExtended);
-        }
-        if (allOrSet(kinds, WriterKinds.PROPERTIES)) {
-            PropertiesWriter.writeReportPropertiesRegressions(rootDir, buildReportExtended);
-        }
-        if (allOrSet(kinds, WriterKinds.PLAIN)) {
-            writePlainTextDiff(prefix, buildReportExtended, rootDir, url);
+    public static void storeAllDiffs(String prefix, PreviousBuilds previousBuilds, File rootDir, String url, List<WriterKinds> kinds) throws IOException {
+        for(int i = 0; i < previousBuilds.getBuilds().length; i++) {
+            if (previousBuilds.getBuilds()[i] == null) {
+                continue;
+            }
+            BuildReportExtended buildReportExtended = purify(previousBuilds.getBuilds()[i]);
+            if (allOrSet(kinds, WriterKinds.JSON)) {
+                File diffJson = new File(rootDir, prefix + "-" + Constants.getReportDiff(previousBuilds.getSuffixes()[i]));
+                JsonReportWriter.writeBuildReportExtended(diffJson, buildReportExtended);
+            }
+            if (allOrSet(kinds, WriterKinds.PROPERTIES)) {
+                PropertiesWriter.writeReportPropertiesRegressions(rootDir, buildReportExtended, previousBuilds.getSuffixes()[i]);
+            }
+            if (allOrSet(kinds, WriterKinds.PLAIN)) {
+                writePlainTextDiff(prefix, buildReportExtended, rootDir, url, previousBuilds.getResolutions()[i], previousBuilds.getSuffixes()[i]);
+            }
         }
     }
 
@@ -90,10 +96,10 @@ public class WritersManager {
         PlainTextWriter.writeAllTestsReport(reportFull, jobName, buildName, buildNumber,allTestsFile.toPath(), url);
     }
 
-    private static void writePlainTextDiff(String prefix, BuildReportExtended buildReportExtended, File rootDir, String url) throws IOException {
+    private static void writePlainTextDiff(String prefix, BuildReportExtended buildReportExtended, File rootDir, String url, String resolution, String suffix) throws IOException {
         // Write diff report
-        File diffFile = new File(rootDir, prefix + "-" + Constants.REPORT_DIFF_TXT);
-        PlainTextWriter.writeDiffReport(buildReportExtended, diffFile.toPath(), url, "latest stable or unstable");
+        File diffFile = new File(rootDir, prefix + "-" + Constants.getReportDiffTxt(suffix));
+        PlainTextWriter.writeDiffReport(buildReportExtended, diffFile.toPath(), url, resolution);
     }
 
     private static BuildReportExtended purify(BuildReportExtended br) {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/WritersManager.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/WritersManager.java
@@ -67,7 +67,7 @@ public class WritersManager {
                 PropertiesWriter.writeReportPropertiesRegressions(rootDir, buildReportExtended, previousBuilds.getSuffixes()[i]);
             }
             if (allOrSet(kinds, WriterKinds.PLAIN)) {
-                writePlainTextDiff(prefix, buildReportExtended, rootDir, url, previousBuilds.getResolutions()[i], previousBuilds.getSuffixes()[i]);
+                writePlainTextDiff(prefix, buildReportExtended, rootDir, url, previousBuilds.getEndpoints()[i], previousBuilds.getResolutions()[i], previousBuilds.getSuffixes()[i]);
             }
         }
     }
@@ -96,10 +96,10 @@ public class WritersManager {
         PlainTextWriter.writeAllTestsReport(reportFull, jobName, buildName, buildNumber,allTestsFile.toPath(), url);
     }
 
-    private static void writePlainTextDiff(String prefix, BuildReportExtended buildReportExtended, File rootDir, String url, String resolution, String suffix) throws IOException {
+    private static void writePlainTextDiff(String prefix, BuildReportExtended buildReportExtended, File rootDir, String url, String endpoint, String resolution, String suffix) throws IOException {
         // Write diff report
         File diffFile = new File(rootDir, prefix + "-" + Constants.getReportDiffTxt(suffix));
-        PlainTextWriter.writeDiffReport(buildReportExtended, diffFile.toPath(), url, resolution);
+        PlainTextWriter.writeDiffReport(buildReportExtended, diffFile.toPath(), url, endpoint,  resolution);
     }
 
     private static BuildReportExtended purify(BuildReportExtended br) {

--- a/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/WritersManager.java
+++ b/report-jtreg-lib/src/main/java/io/jenkins/plugins/report/jtreg/writers/WritersManager.java
@@ -93,11 +93,11 @@ public class WritersManager {
     private static void writePlainTextDiff(String prefix, BuildReportExtended buildReportExtended, File rootDir, String url) throws IOException {
         // Write diff report
         File diffFile = new File(rootDir, prefix + "-" + Constants.REPORT_DIFF_TXT);
-        PlainTextWriter.writeDiffReport(buildReportExtended, diffFile.toPath(), url);
+        PlainTextWriter.writeDiffReport(buildReportExtended, diffFile.toPath(), url, "latest stable or unstable");
     }
 
     private static BuildReportExtended purify(BuildReportExtended br) {
-        return new BuildReportExtended(br.getBuildNumber(), br.getBuildName(), br.getPassed(), br.getFailed(), br.getError(), null, br.getAddedSuites(), br.getRemovedSuites(), br.getTestChanges(), br.getTotal(), br.getNotRun(), null, br.getJob(), br.getTimestamp(), br.getDuration());
+        return new BuildReportExtended(br.getBuildNumber(), br.getBuildName(), br.getPassed(), br.getFailed(), br.getError(), null, br.getAddedSuites(), br.getRemovedSuites(), br.getTestChanges(), br.getTotal(), br.getNotRun(), null, br.getJob(), br.getTimestamp(), br.getDuration(), br.getComparedAgainstBuildNumber(), br.getComparedAgainstBuildName(), br.getComparedAgainstStart(), br.getComparedAgainstDuration());
     }
 
 }

--- a/report-jtreg-list/src/main/java/io/jenkins/plugins/report/jtreg/main/recreate/Recreate.java
+++ b/report-jtreg-list/src/main/java/io/jenkins/plugins/report/jtreg/main/recreate/Recreate.java
@@ -20,6 +20,7 @@ public class Recreate implements PrefixableResult {
 
     public Recreate(RecreateArgs args) {
         this.args = args;
+        args.initCommandlineSecondComparison();
     }
 
     public static void main(String[] aargs) throws Exception {

--- a/report-jtreg/pom.xml
+++ b/report-jtreg/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>report-jtreg-lib</artifactId>
-            <version>5.0.2-SNAPSHOT</version>
+            <version>${revision}${changelist}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportAction.java
@@ -70,7 +70,7 @@ public abstract class AbstractReportAction implements Action, StaplerProxy, Simp
     public BuildReportExtended getTarget() {
         try {
             AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(build.getProject().getPublishersList());
-            PreviousBuilds reports = new BuildSummaryParserPlugin(prefixes, settings).parseBuildReportExtended(build);
+            PreviousBuilds reports = new BuildSummaryParserPlugin(prefixes, settings, getUrlName()).parseBuildReportExtended(build);
             return getRealTarget(reports);
         } catch (Exception ex) {
             ex.printStackTrace();

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportAction.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015-2023 report-jtreg plugin contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.plugins.report.jtreg;
+
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
+import hudson.model.Job;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import jenkins.tasks.SimpleBuildStep;
+import org.kohsuke.stapler.StaplerProxy;
+
+public abstract class AbstractReportAction implements Action, StaplerProxy, SimpleBuildStep.LastBuildAction {
+
+    protected final AbstractBuild<?, ?> build;
+    protected final Set<String> prefixes = new HashSet<>();
+
+    public AbstractReportAction(AbstractBuild<?, ?> build) {
+        if (build == null) {
+            throw new IllegalArgumentException("Build cannot be null");
+        }
+        this.build = build;
+    }
+
+    public void addPrefix(String prefix) {
+        if (prefix == null || prefix.trim().isEmpty()) {
+            throw new IllegalArgumentException("Prefix cannot be empty");
+        }
+        prefixes.add(prefix);
+    }
+
+    @Override
+    public String getIconFileName() {
+        return "graph.png";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return prefixes.stream()
+                .sequential()
+                .map(s -> s.toUpperCase())
+                .collect(Collectors.joining(", ", "", " " + getReportSuffix()));
+    }
+
+    @Override
+    public BuildReportExtended getTarget() {
+        try {
+            AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(build.getProject().getPublishersList());
+            PreviousBuilds reports = new BuildSummaryParserPlugin(prefixes, settings).parseBuildReportExtended(build);
+            return getRealTarget(reports);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<? extends Action> getProjectActions() {
+        Job<?, ?> job = build.getParent();
+        return Collections.singleton(createProjectAction(job, prefixes));
+    }
+
+    protected abstract String getReportSuffix();
+
+    protected abstract Action createProjectAction(Job<?, ?> job, Set<String> prefixes);
+
+    protected abstract BuildReportExtended getRealTarget(PreviousBuilds reports);
+}
+
+// Made with Bob

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportProjectAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportProjectAction.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015-2023 report-jtreg plugin contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.jenkins.plugins.report.jtreg;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Project;
+import io.jenkins.plugins.report.jtreg.model.ProjectReport;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public abstract class AbstractReportProjectAction implements Action {
+
+    protected final Job<?, ?> job;
+    protected final Set<String> prefixes = new HashSet<>();
+
+    public AbstractReportProjectAction(Job<?, ?> job, Set<String> prefixes) {
+        if (job == null) {
+            throw new IllegalArgumentException("Job cannot be null");
+        }
+        if (prefixes == null || prefixes.isEmpty()) {
+            throw new IllegalArgumentException("Prefixes cannot be null or empty");
+        }
+        this.job = job;
+        this.prefixes.addAll(prefixes);
+    }
+
+    public void addPrefix(String prefix) {
+        prefixes.add(prefix);
+    }
+
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(((Project)job).getPublishersList());
+        List<String> blisted = new BuildSummaryParserPlugin(prefixes, settings).getDenylisted(job);
+        List<String> wlisted = new BuildSummaryParserPlugin(prefixes, settings).getAllowlisted(job);
+        int allowListSizeWithoutSurroundings = new BuildSummaryParserPlugin(prefixes, settings).getAllowListSizeWithoutSurroundings(job);
+        String appendix = "";
+        if (blisted.size() > 0 && wlisted.size() > 0) {
+            appendix = " (denylisted " + blisted.size() + ")" + " (allowlisted " + allowListSizeWithoutSurroundings + "/" + Integer.toString(wlisted.size()-allowListSizeWithoutSurroundings) + ")";
+        } else if (blisted.size() > 0) {
+            appendix = " (denylisted " + blisted.size() + ")";
+        } else if (wlisted.size() > 0) {
+            appendix = " (allowlisted " + allowListSizeWithoutSurroundings + "/" + Integer.toString(wlisted.size()-allowListSizeWithoutSurroundings) + ")";
+        }
+        return prefixes.stream()
+                .sequential()
+                .map(s -> s.toUpperCase())
+                .collect(Collectors.joining(", ", "", " " + getReportSuffix() + appendix));
+    }
+
+    // This is called when chart is shown on main page
+    public ProjectReport getChartData() {
+        ProjectReport report = ReportProjectActionUtils.getReport(prefixes, (Project) job, 0);
+        return report;
+    }
+
+    protected abstract String getReportSuffix();
+}
+
+// Made with Bob

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportProjectAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportProjectAction.java
@@ -61,9 +61,9 @@ public abstract class AbstractReportProjectAction implements Action {
     @Override
     public String getDisplayName() {
         AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(((Project)job).getPublishersList());
-        List<String> blisted = new BuildSummaryParserPlugin(prefixes, settings).getDenylisted(job);
-        List<String> wlisted = new BuildSummaryParserPlugin(prefixes, settings).getAllowlisted(job);
-        int allowListSizeWithoutSurroundings = new BuildSummaryParserPlugin(prefixes, settings).getAllowListSizeWithoutSurroundings(job);
+        List<String> blisted = new BuildSummaryParserPlugin(prefixes, settings, getUrlName()).getDenylisted(job);
+        List<String> wlisted = new BuildSummaryParserPlugin(prefixes, settings, getUrlName()).getAllowlisted(job);
+        int allowListSizeWithoutSurroundings = new BuildSummaryParserPlugin(prefixes, settings, getUrlName()).getAllowListSizeWithoutSurroundings(job);
         String appendix = "";
         if (blisted.size() > 0 && wlisted.size() > 0) {
             appendix = " (denylisted " + blisted.size() + ")" + " (allowlisted " + allowListSizeWithoutSurroundings + "/" + Integer.toString(wlisted.size()-allowListSizeWithoutSurroundings) + ")";
@@ -85,6 +85,8 @@ public abstract class AbstractReportProjectAction implements Action {
     }
 
     protected abstract String getReportSuffix();
+    
+    public abstract String getUrlName();
 }
 
 // Made with Bob

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
@@ -123,6 +123,15 @@ abstract public class AbstractReportPublisher extends Recorder {
         } else {
             action.addPrefix(prefix());
         }
+        
+        ExactReportAction exactAction = build.getAction(ExactReportAction.class);
+        if (exactAction == null) {
+            exactAction = new ExactReportAction(build);
+            exactAction.addPrefix(prefix());
+            build.addAction(exactAction);
+        } else {
+            exactAction.addPrefix(prefix());
+        }
     }
 
     @Override

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
@@ -89,7 +89,7 @@ abstract public class AbstractReportPublisher extends Recorder {
         //first we create the jsons for this run
         WritersManager.storeAllSummaries(prefix(),report, build.getRootDir(), build.getDisplayName(), Jenkins.get().getRootUrl(), null);
         //now we can reuse them to compute diff
-        BuildSummaryParserPlugin bsp = new BuildSummaryParserPlugin(Arrays.asList(prefix()), ReportAction.getAbstractReportPublisher(build.getProject().getPublishersList()));
+        BuildSummaryParserPlugin bsp = new BuildSummaryParserPlugin(Arrays.asList(prefix()), ReportAction.getAbstractReportPublisher(build.getProject().getPublishersList()), "noLinksSholdBeUsed");
         try {
             SecondComparison.getOrCreateInstance(() -> JenkinsReportJckGlobalConfig.getGlobalDisplayNameComparisonURL());
             PreviousBuilds previousBuilds = bsp.parseBuildReportExtended(build);

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
@@ -93,6 +93,7 @@ abstract public class AbstractReportPublisher extends Recorder {
         BuildSummaryParserPlugin bsp = new BuildSummaryParserPlugin(Arrays.asList(prefix()), ReportAction.getAbstractReportPublisher(build.getProject().getPublishersList()));
         try {
             BuildReportExtended br = bsp.parseBuildReportExtended(build);
+            SecondComparison.getOrCreateInstance(() -> JenkinsReportJckGlobalConfig.getGlobalDisplayNameComparisonURL());
             //recreating without full listings
             WritersManager.storeAllDiffs(prefix(), br, build.getRootDir(), Jenkins.get().getRootUrl(), null);
             String targetFolders = JenkinsReportJckGlobalConfig.getGlobalTargetFolders();

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/AbstractReportPublisher.java
@@ -86,16 +86,15 @@ abstract public class AbstractReportPublisher extends Recorder {
             logger.severe(s);
             build.setResult(Result.FAILURE);
         }
-        //FIXME, verify on remote agent
         //first we create the jsons for this run
         WritersManager.storeAllSummaries(prefix(),report, build.getRootDir(), build.getDisplayName(), Jenkins.get().getRootUrl(), null);
         //now we can reuse them to compute diff
         BuildSummaryParserPlugin bsp = new BuildSummaryParserPlugin(Arrays.asList(prefix()), ReportAction.getAbstractReportPublisher(build.getProject().getPublishersList()));
         try {
-            BuildReportExtended br = bsp.parseBuildReportExtended(build);
             SecondComparison.getOrCreateInstance(() -> JenkinsReportJckGlobalConfig.getGlobalDisplayNameComparisonURL());
+            PreviousBuilds previousBuilds = bsp.parseBuildReportExtended(build);
             //recreating without full listings
-            WritersManager.storeAllDiffs(prefix(), br, build.getRootDir(), Jenkins.get().getRootUrl(), null);
+            WritersManager.storeAllDiffs(prefix(), previousBuilds, build.getRootDir(), Jenkins.get().getRootUrl(), null);
             String targetFolders = JenkinsReportJckGlobalConfig.getGlobalTargetFolders();
             if (targetFolders != null && !targetFolders.isBlank()) {
                 String additionalFiles = JenkinsReportJckGlobalConfig.getGlobalAdditionalFilesToCopy();
@@ -104,7 +103,7 @@ abstract public class AbstractReportPublisher extends Recorder {
                         prefix(),
                         build.getRootDir().toPath(),
                         RecreateArgs.fromJenkins(additionalFiles, targetFolders, prefix(), Jenkins.get().getRootUrl(), kinds),
-                        null, build.getDisplayName(), br, build.getNumber(),build.getResult() == null?"UNKNOWN":build.getResult().toString());
+                        null, build.getDisplayName(), previousBuilds.getLastStableUnstableBuild(), build.getNumber(),build.getResult() == null?"UNKNOWN":build.getResult().toString());
             }
         }catch ( Exception e) {
             e.printStackTrace();

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -48,7 +48,9 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
                                 UrlsProvider urlProvider) {
         super(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites, testChanges, total, notRun, allTests, job, timestamp, duration, comparedAgainstBuildNumber, comparedAgainstBuildName, comparedAgainstStart, comparedAgainstDuration);
         this.urlsProvider = urlProvider;
-        allTests.setUrlProviser(urlsProvider);
+        if (allTests!=null) {
+            allTests.setUrlProviser(urlsProvider);
+        }
     }
 
     public List<ComparatorLinksGroup> getMatchedComparatorLinksGroups() {

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -43,8 +43,10 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
 
     public BuildReportExtendedPlugin(int buildNumber, String buildName, int passed, int failed, int error, List<Suite> suites,
                                List<String> addedSuites, List<String> removedSuites, List<SuiteTestChanges> testChanges, int total,
-                                int notRun, SuitesWithResults allTests, String job, long timestamp, long duration, UrlsProvider urlProvider) {
-        super(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites, testChanges, total, notRun, allTests, job, timestamp, duration);
+                                int notRun, SuitesWithResults allTests, String job, long timestamp, long duration,
+                                int comparedAgainstBuildNumber, String comparedAgainstBuildName, long comparedAgainstStart, long comparedAgainstDuration,
+                                UrlsProvider urlProvider) {
+        super(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites, testChanges, total, notRun, allTests, job, timestamp, duration, comparedAgainstBuildNumber, comparedAgainstBuildName, comparedAgainstStart, comparedAgainstDuration);
         this.urlsProvider = urlProvider;
         allTests.setUrlProviser(urlsProvider);
     }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin.java
@@ -40,14 +40,15 @@ import java.util.regex.Pattern;
 public class BuildReportExtendedPlugin extends BuildReportExtended {
 
     private final UrlsProvider urlsProvider;
+    private final String endpoint;
 
     public BuildReportExtendedPlugin(int buildNumber, String buildName, int passed, int failed, int error, List<Suite> suites,
                                List<String> addedSuites, List<String> removedSuites, List<SuiteTestChanges> testChanges, int total,
                                 int notRun, SuitesWithResults allTests, String job, long timestamp, long duration,
-                                int comparedAgainstBuildNumber, String comparedAgainstBuildName, long comparedAgainstStart, long comparedAgainstDuration,
-                                UrlsProvider urlProvider) {
+                                int comparedAgainstBuildNumber, String comparedAgainstBuildName, long comparedAgainstStart, long comparedAgainstDuration, UrlsProvider urlProvider, String endpoint) {
         super(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites, testChanges, total, notRun, allTests, job, timestamp, duration, comparedAgainstBuildNumber, comparedAgainstBuildName, comparedAgainstStart, comparedAgainstDuration);
         this.urlsProvider = urlProvider;
+        this.endpoint = endpoint;
         if (allTests!=null) {
             allTests.setUrlProviser(urlsProvider);
         }
@@ -220,5 +221,56 @@ public class BuildReportExtendedPlugin extends BuildReportExtended {
             return url + "?generated-part=&custom-part=";
         }
     }
+
+    private String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getPreviousLink() {
+        return "../../" + (getBuildNumber() - 1) + "/" + getEndpoint();
+    }
+
+    public String getPreviousLinkName() {
+        return " << " + (getBuildNumber() - 1) + " << ";
+    }
+
+    public String getNextLink() {
+        return "../../" + (getBuildNumber() + 1) + "/" + getEndpoint();
+    }
+
+    public String getNextLinkName() {
+        return " >> " + (getBuildNumber() + 1) + " >> ";
+    }
+
+
+    public String getCustomTitle() {
+        return this.job + ": " + getBuildNumber() + "/" + getBuildNumber() + " compared to: " + getComparedAgainstCaption();
+    }
+
+    public String getComparedAgainstCaption() {
+        return comparedAgainstBuildNumber + "(" + comparedAgainstBuildName + ")";
+    }
+
+    public String getComparedAgainstLink() {
+        return "../../" + (comparedAgainstBuildNumber) + "/" + getEndpoint();
+    }
+
+    public boolean getSecondaryReport() {
+        return PreviousBuilds.SECOND_ENDPOINT.equals(getEndpoint());
+    }
+
+    public String getSecondaryReportLink() {
+        return "../"+PreviousBuilds.SECOND_ENDPOINT;
+    }
+    public String getSecondaryReportText() {
+        return "exact build comparison";
+    }
+    public String getMainReportLink() {
+        return "../"+PreviousBuilds.DEFAULT_ENDPOINT;
+    }
+    public String getMainReportText() {
+        return "previous build comparison";
+    }
+
 
 }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginFactory.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginFactory.java
@@ -10,7 +10,12 @@ import java.util.List;
 
 public class BuildReportExtendedPluginFactory extends BuildReportExtendedFactory {
 
-    private static final UrlsProvider urlsProvider= new UrlsProviderPlugin();
+    private static final UrlsProvider urlsProvider = new UrlsProviderPlugin();
+    private final String endpoint;
+
+    public BuildReportExtendedPluginFactory(String endpoint) {
+        this.endpoint = endpoint;
+    }
 
     @Override
     public BuildReportExtended createBuildReportExtended(int buildNumber, String buildName, int passed, int failed,
@@ -20,6 +25,6 @@ public class BuildReportExtendedPluginFactory extends BuildReportExtendedFactory
                                                                long timestamp, long duration,
                                                                int comparedAgainstBuildNumber, String comparedAgainstBuildName, long comparedAgainstStart, long comparedAgainstDuration) {
         return new BuildReportExtendedPlugin(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites,
-                testChanges, total, notRun, allTests, job, timestamp, duration, comparedAgainstBuildNumber, comparedAgainstBuildName, comparedAgainstStart, comparedAgainstDuration, urlsProvider);
+                testChanges, total, notRun, allTests, job, timestamp, duration, comparedAgainstBuildNumber, comparedAgainstBuildName, comparedAgainstStart, comparedAgainstDuration, urlsProvider, endpoint);
     }
 }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginFactory.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginFactory.java
@@ -16,8 +16,10 @@ public class BuildReportExtendedPluginFactory extends BuildReportExtendedFactory
     public BuildReportExtended createBuildReportExtended(int buildNumber, String buildName, int passed, int failed,
                                                                int error, List<Suite> suites, List<String> addedSuites,
                                                                List<String> removedSuites, List<SuiteTestChanges> testChanges,
-                                                               int total, int notRun, SuitesWithResults allTests, String job, long timestamp, long duration) {
+                                                               int total, int notRun, SuitesWithResults allTests, String job,
+                                                               long timestamp, long duration,
+                                                               int comparedAgainstBuildNumber, String comparedAgainstBuildName, long comparedAgainstStart, long comparedAgainstDuration) {
         return new BuildReportExtendedPlugin(buildNumber, buildName, passed, failed, error, suites, addedSuites, removedSuites,
-                testChanges, total, notRun, allTests, job, timestamp, duration, urlsProvider);
+                testChanges, total, notRun, allTests, job, timestamp, duration, comparedAgainstBuildNumber, comparedAgainstBuildName, comparedAgainstStart, comparedAgainstDuration, urlsProvider);
     }
 }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParserPlugin.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParserPlugin.java
@@ -51,11 +51,11 @@ public class BuildSummaryParserPlugin extends BuildSummaryParser {
     }
     private final AbstractReportPublisher settings;
 
-    public BuildSummaryParserPlugin(Collection<String> prefixes, AbstractReportPublisher settings) {
+    public BuildSummaryParserPlugin(Collection<String> prefixes, AbstractReportPublisher settings, String endpoint) {
         super(prefixes, urlsProvider);
         this.prefixes.addAll(prefixes);
         this.settings = settings;
-        this.buildReportExtendedFactory = new BuildReportExtendedPluginFactory();
+        this.buildReportExtendedFactory = new BuildReportExtendedPluginFactory(endpoint);
     }
 
     List<String> getDenylisted(Job<?, ?> job) {

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParserPlugin.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParserPlugin.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
+
 import io.jenkins.plugins.report.jtreg.wrappers.RunWrapperFromRun;
 import hudson.util.RunList;
 
@@ -239,10 +241,9 @@ public class BuildSummaryParserPlugin extends BuildSummaryParser {
     }
 
     @SuppressFBWarnings(value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}, justification = " npe of spotbugs sucks")
-    public BuildReportExtended parseBuildReportExtended(Run<?, ?> build) throws Exception {
+    public PreviousBuilds parseBuildReportExtended(Run<?, ?> build) throws Exception {
         AbstractProject project = ((AbstractBuild) build).getProject();
         Run[] builds = (Run[]) project.getBuilds().toArray(new Run[0]);
-        RunWrapperFromRun previousPassedOrUnstable = null;
         //0 is latest one eg #115, where [lenght-1] is first  one = #0
         int thisInArray = -1;
         for (int i = 0; i < builds.length; i++) {
@@ -255,14 +256,46 @@ public class BuildSummaryParserPlugin extends BuildSummaryParser {
         if (thisInArray == -1) {
             System.err.println("Warning " + build.toString() + " not found in builds of #" + builds.length);
         }
+        RunWrapperFromRun previousPassedOrUnstable = getPreviousStableOrUnstableBuild(thisInArray, builds);
+        BuildReportExtended previousPassedOrUnstableReport = parseBuildReportExtended(new RunWrapperFromRun(build), previousPassedOrUnstable);
+        RunWrapperFromRun previousExactBuild = getPreviousExactBuild(thisInArray, builds);
+        BuildReportExtended previousExactBuildReport = null;
+        if (previousExactBuild != null) {
+            previousExactBuildReport = parseBuildReportExtended(new RunWrapperFromRun(build), previousExactBuild);
+        }
+        return new PreviousBuilds(previousPassedOrUnstableReport, previousExactBuildReport);
+    }
+
+
+    private RunWrapperFromRun getPreviousStableOrUnstableBuild(int thisInArray, Run[] builds) {
+        return getPreviousBuild(thisInArray, builds, PreviousBuilds.getAllPredicate(), Integer.MAX_VALUE);
+    }
+
+    private RunWrapperFromRun getPreviousExactBuild(int thisInArray, Run[] builds) {
+        List<String> displayNamesToFind = SecondComparison.getInstance().getList();
+        if (displayNamesToFind != null) {
+            return getPreviousBuild(thisInArray, builds, PreviousBuilds.createPredicate(displayNamesToFind), getMaxItems());
+        }
+        return null;
+    }
+
+    @SuppressFBWarnings(value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = " npe of spotbugs sucks")
+    private static RunWrapperFromRun getPreviousBuild(int thisInArray, Run[] builds, Predicate<String> predicate, int secondaryCounter) {
+        RunWrapperFromRun previousPassedOrUnstable = null;
         for (int i = thisInArray + 1; i < builds.length; i++) {
+            secondaryCounter--;
+            if (secondaryCounter < 0) {
+                return null;
+            }
             Run run = builds[i];
             if (run != null && run.getResult() != null && !run.getResult().isWorseThan(Result.UNSTABLE)) {
-                previousPassedOrUnstable = new RunWrapperFromRun(run);
-                break;
+                if (predicate.test(run.getDisplayName())) {
+                    previousPassedOrUnstable = new RunWrapperFromRun(run);
+                    break;
+                }
             }
         }
-        return parseBuildReportExtended(new RunWrapperFromRun(build), previousPassedOrUnstable);
+        return previousPassedOrUnstable;
     }
 
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Alhoug never called, this method is here to demonstrate (and ocassionally being used) how to access the root dir from run/build")

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParserPlugin.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/BuildSummaryParserPlugin.java
@@ -272,7 +272,7 @@ public class BuildSummaryParserPlugin extends BuildSummaryParser {
     }
 
     private RunWrapperFromRun getPreviousExactBuild(int thisInArray, Run[] builds) {
-        List<String> displayNamesToFind = SecondComparison.getInstance().getList();
+        List<String> displayNamesToFind =  SecondComparison.getOrCreateInstance(() -> JenkinsReportJckGlobalConfig.getGlobalDisplayNameComparisonURL()).getList();
         if (displayNamesToFind != null) {
             return getPreviousBuild(thisInArray, builds, PreviousBuilds.createPredicate(displayNamesToFind), getMaxItems());
         }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportAction.java
@@ -36,7 +36,7 @@ public class ExactReportAction extends AbstractReportAction {
 
     @Override
     public String getUrlName() {
-        return "exact-java-reports";
+        return PreviousBuilds.SECOND_ENDPOINT;
     }
 
     @Override

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportAction.java
@@ -23,22 +23,35 @@
  */
 package io.jenkins.plugins.report.jtreg;
 
+import hudson.model.AbstractBuild;
+import hudson.model.Action;
 import hudson.model.Job;
 import java.util.Set;
 
-public class ReportProjectAction extends AbstractReportProjectAction {
+public class ExactReportAction extends AbstractReportAction {
 
-    public ReportProjectAction(Job<?, ?> job, Set<String> prefixes) {
-        super(job, prefixes);
+    public ExactReportAction(AbstractBuild<?, ?> build) {
+        super(build);
     }
 
     @Override
     public String getUrlName() {
-        return "java-reports";
+        return "exact-java-reports";
     }
 
     @Override
     protected String getReportSuffix() {
-        return "Reports";
+        return "Exact Reports";
     }
+
+    @Override
+    protected Action createProjectAction(Job<?, ?> job, Set<String> prefixes) {
+        return new ExactReportProjectAction(job, prefixes);
+    }
+
+    @Override
+    protected BuildReportExtended getRealTarget(PreviousBuilds reports) {
+        return reports.getLastNamedStableUnstableBuild();
+    }
+
 }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportProjectAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportProjectAction.java
@@ -34,7 +34,7 @@ public class ExactReportProjectAction extends AbstractReportProjectAction {
 
     @Override
     public String getUrlName() {
-        return "exact-java-reports";
+        return PreviousBuilds.SECOND_ENDPOINT;
     }
 
     @Override

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportProjectAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ExactReportProjectAction.java
@@ -26,19 +26,21 @@ package io.jenkins.plugins.report.jtreg;
 import hudson.model.Job;
 import java.util.Set;
 
-public class ReportProjectAction extends AbstractReportProjectAction {
+public class ExactReportProjectAction extends AbstractReportProjectAction {
 
-    public ReportProjectAction(Job<?, ?> job, Set<String> prefixes) {
+    public ExactReportProjectAction(Job<?, ?> job, Set<String> prefixes) {
         super(job, prefixes);
     }
 
     @Override
     public String getUrlName() {
-        return "java-reports";
+        return "exact-java-reports";
     }
 
     @Override
     protected String getReportSuffix() {
-        return "Reports";
+        return "Exact Reports";
     }
 }
+
+// Made with Bob

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig.java
@@ -32,6 +32,7 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
     String additionalFilesToCopy;
     String targetFolders;
     String kinds;
+    String displayNameComparisonURL;
     List<ComparatorLinksGroup> comparatorLinksGroups;
     List<ConfigItem> configItems;
     List<TestLink> testLinks;
@@ -102,6 +103,44 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
 
     public static String getGlobalKinds() {
         return getInstance().getKinds();
+    }
+
+    public String getDisplayNameComparisonURL() {
+        return displayNameComparisonURL;
+    }
+
+    @DataBoundSetter
+    public void setDisplayNameComparisonURL(String displayNameComparisonURL) {
+        this.displayNameComparisonURL = displayNameComparisonURL;
+    }
+
+    public static String getGlobalDisplayNameComparisonURL() {
+        return getInstance().getDisplayNameComparisonURL();
+    }
+
+    /**
+     * Validates the displayNameComparisonURL field to ensure it is a valid URL.
+     * @param value the URL string
+     * @return FormValidation result
+     */
+    public FormValidation doCheckDisplayNameComparisonURL(@QueryParameter String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return FormValidation.ok();
+        }
+
+        String trimmed = value.trim();
+        
+        // Basic URL validation
+        if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) {
+            return FormValidation.error("URL must start with http:// or https://");
+        }
+
+        try {
+            new java.net.URL(trimmed);
+            return FormValidation.ok();
+        } catch (java.net.MalformedURLException e) {
+            return FormValidation.error("Invalid URL format: " + e.getMessage());
+        }
     }
 
     /**
@@ -273,11 +312,12 @@ public class JenkinsReportJckGlobalConfig extends GlobalConfiguration {
     }
 
     @DataBoundConstructor
-    public JenkinsReportJckGlobalConfig(String toolsUrl, String additionalFilesToCopy, String targetFolders, String kinds, List<ComparatorLinksGroup> comparatorLinksGroups, List<ConfigItem> configItems, List<TestLink> testLinks) {
+    public JenkinsReportJckGlobalConfig(String toolsUrl, String additionalFilesToCopy, String targetFolders, String kinds, String displayNameComparisonURL, List<ComparatorLinksGroup> comparatorLinksGroups, List<ConfigItem> configItems, List<TestLink> testLinks) {
         this.toolsUrl = toolsUrl;
         this.additionalFilesToCopy = additionalFilesToCopy;
         this.targetFolders = targetFolders;
         this.kinds = kinds;
+        this.displayNameComparisonURL = displayNameComparisonURL;
         this.comparatorLinksGroups = comparatorLinksGroups;
         this.configItems = configItems;
         this.testLinks = testLinks;

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
@@ -29,44 +29,12 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
-import jenkins.tasks.SimpleBuildStep;
-import org.kohsuke.stapler.StaplerProxy;
 
-public class ReportAction implements Action, StaplerProxy, SimpleBuildStep.LastBuildAction {
-
-    private final AbstractBuild<?, ?> build;
-    private final Set<String> prefixes = new HashSet<>();
+public class ReportAction extends AbstractReportAction {
 
     public ReportAction(AbstractBuild<?, ?> build) {
-        if (build == null) {
-            throw new IllegalArgumentException("Build cannot be null");
-        }
-        this.build = build;
-    }
-
-    public void addPrefix(String prefix) {
-        if (prefix == null || prefix.trim().isEmpty()) {
-            throw new IllegalArgumentException("Prefix cannot be empty");
-        }
-        prefixes.add(prefix);
-    }
-
-    @Override
-    public String getIconFileName() {
-        return "graph.png";
-    }
-
-    @Override
-    public String getDisplayName() {
-        return prefixes.stream()
-                .sequential()
-                .map(s -> s.toUpperCase())
-                .collect(Collectors.joining(", ", "", " Reports"));
+        super(build);
     }
 
     @Override
@@ -75,21 +43,18 @@ public class ReportAction implements Action, StaplerProxy, SimpleBuildStep.LastB
     }
 
     @Override
-    public BuildReportExtended getTarget() {
-        try {
-            AbstractReportPublisher settings = getAbstractReportPublisher(build.getProject().getPublishersList());
-            PreviousBuilds reports = new BuildSummaryParserPlugin(prefixes, settings).parseBuildReportExtended(build);
-            return reports.getLastStableUnstableBuild();
-        } catch (Exception ex) {
-            ex.printStackTrace();
-        }
-        return null;
+    protected String getReportSuffix() {
+        return "Reports";
     }
 
     @Override
-    public Collection<? extends Action> getProjectActions() {
-        Job<?, ?> job = build.getParent();
-        return Collections.singleton(new ReportProjectAction(job, prefixes));
+    protected Action createProjectAction(Job<?, ?> job, Set<String> prefixes) {
+        return new ReportProjectAction(job, prefixes);
+    }
+
+    @Override
+    protected BuildReportExtended getRealTarget(PreviousBuilds reports) {
+        return reports.getLastStableUnstableBuild();
     }
 
     public static  AbstractReportPublisher getAbstractReportPublisher(DescribableList<Publisher, Descriptor<Publisher>> publishersList) {

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
@@ -75,11 +75,11 @@ public class ReportAction implements Action, StaplerProxy, SimpleBuildStep.LastB
     }
 
     @Override
-    public BuildReportExtended getTarget() {
+    public PreviousBuilds getTarget() {
         try {
             AbstractReportPublisher settings = getAbstractReportPublisher(build.getProject().getPublishersList());
-            BuildReportExtended report = new BuildSummaryParserPlugin(prefixes, settings).parseBuildReportExtended(build);
-            return report;
+            PreviousBuilds reports = new BuildSummaryParserPlugin(prefixes, settings).parseBuildReportExtended(build);
+            return reports;
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
@@ -39,7 +39,7 @@ public class ReportAction extends AbstractReportAction {
 
     @Override
     public String getUrlName() {
-        return "java-reports";
+        return PreviousBuilds.DEFAULT_ENDPOINT;
     }
 
     @Override

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportAction.java
@@ -75,11 +75,11 @@ public class ReportAction implements Action, StaplerProxy, SimpleBuildStep.LastB
     }
 
     @Override
-    public PreviousBuilds getTarget() {
+    public BuildReportExtended getTarget() {
         try {
             AbstractReportPublisher settings = getAbstractReportPublisher(build.getProject().getPublishersList());
             PreviousBuilds reports = new BuildSummaryParserPlugin(prefixes, settings).parseBuildReportExtended(build);
-            return reports;
+            return reports.getLastStableUnstableBuild();
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportChartColumn.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportChartColumn.java
@@ -47,7 +47,7 @@ public class ReportChartColumn extends ListViewColumn {
 
     public List<BuildReportPlugin> getJckReport(Job<?, ?> job) {
         AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(((Project) job).getPublishersList());
-        List<BuildReportPlugin> r = new BuildSummaryParserPlugin(Arrays.asList("jck", "jtreg"), settings).parseJobReports(job, 0);
+        List<BuildReportPlugin> r = new BuildSummaryParserPlugin(Arrays.asList("jck", "jtreg"), settings, PreviousBuilds.DEFAULT_ENDPOINT).parseJobReports(job, 0);
         return r;
     }
 

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectAction.java
@@ -27,7 +27,6 @@ import hudson.model.Action;
 import hudson.model.Job;
 import hudson.model.Project;
 import io.jenkins.plugins.report.jtreg.model.ProjectReport;
-import io.jenkins.plugins.report.jtreg.writers.PropertiesWriter;
 
 import java.util.HashSet;
 import java.util.List;

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectAction.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectAction.java
@@ -34,7 +34,7 @@ public class ReportProjectAction extends AbstractReportProjectAction {
 
     @Override
     public String getUrlName() {
-        return "java-reports";
+        return PreviousBuilds.DEFAULT_ENDPOINT;
     }
 
     @Override

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
@@ -45,10 +45,11 @@ public class ReportProjectActionUtils  {
         AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(job.getPublishersList());
         BuildSummaryParserPlugin bsp = new BuildSummaryParserPlugin(prefixes, settings, "endpointShouldNotMetter");
         List<? extends BuildReport> reports = bsp.parseJobReports(job, limitOverwrite);
-        List<String> displayNamesToFind = SecondComparison.getInstance().getList();SecondComparison.getOrCreateInstance(() -> JenkinsReportJckGlobalConfig.getGlobalDisplayNameComparisonURL());
+        List<String> displayNamesToFind = SecondComparison.getOrCreateInstance(() -> JenkinsReportJckGlobalConfig.getGlobalDisplayNameComparisonURL()).getList();
         BuildReport foundBuildReport = null;
+        RunWrapper found = null;
         if (displayNamesToFind != null) {
-            RunWrapper found = ReportSummaryUtil.findPreviousBuild(new File(job.asProject().getRootDir(), "weNeedPArent").toPath(), job.getLastBuild().getNumber(), PreviousBuilds.createPredicate(displayNamesToFind), settings.getIntMaxBuilds());
+            found = ReportSummaryUtil.findPreviousBuild(new File(job.asProject().getRootDir(), "builds/weNeedPArent").toPath(), job.getLastBuild().getNumber(), PreviousBuilds.createPredicate(displayNamesToFind), settings.getIntMaxBuilds());
             if (found != null) {
                 try {
                     foundBuildReport = bsp.parseBuildReport(found);
@@ -62,7 +63,8 @@ public class ReportProjectActionUtils  {
                 collectImprovements(reports),
                 collectRegressions(reports),
                 collectImprovementsAgainst(foundBuildReport, reports),
-                collectRegressionsAgainst(foundBuildReport, reports));
+                collectRegressionsAgainst(foundBuildReport, reports),
+                found);
         return report;
     }
 

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
@@ -37,7 +37,7 @@ public class ReportProjectActionUtils  {
 
     public static ProjectReport getReport(Set<String> prefixes, Project job,  int limitOverwrite) {
         AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(job.getPublishersList());
-        List<? extends BuildReport> reports = new BuildSummaryParserPlugin(prefixes, settings).parseJobReports(job, limitOverwrite);
+        List<? extends BuildReport> reports = new BuildSummaryParserPlugin(prefixes, settings, PreviousBuilds.DEFAULT_ENDPOINT).parseJobReports(job, limitOverwrite);
         ProjectReport report = new ProjectReport(
                 reports,
                 collectImprovements(reports),

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
@@ -23,25 +23,46 @@
  */
 package io.jenkins.plugins.report.jtreg;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Project;
 import io.jenkins.plugins.report.jtreg.model.BuildReport;
 import io.jenkins.plugins.report.jtreg.model.ProjectReport;
+import io.jenkins.plugins.report.jtreg.recreate.ReportSummaryUtil;
+import io.jenkins.plugins.report.jtreg.wrappers.RunWrapper;
 
 public class ReportProjectActionUtils  {
 
+    @SuppressFBWarnings(value = {"NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"}, justification = " npe of spotbugs sucks")
     public static ProjectReport getReport(Set<String> prefixes, Project job,  int limitOverwrite) {
         AbstractReportPublisher settings = ReportAction.getAbstractReportPublisher(job.getPublishersList());
-        List<? extends BuildReport> reports = new BuildSummaryParserPlugin(prefixes, settings, PreviousBuilds.DEFAULT_ENDPOINT).parseJobReports(job, limitOverwrite);
+        BuildSummaryParserPlugin bsp = new BuildSummaryParserPlugin(prefixes, settings, "endpointShouldNotMetter");
+        List<? extends BuildReport> reports = bsp.parseJobReports(job, limitOverwrite);
+        List<String> displayNamesToFind = SecondComparison.getInstance().getList();SecondComparison.getOrCreateInstance(() -> JenkinsReportJckGlobalConfig.getGlobalDisplayNameComparisonURL());
+        BuildReport foundBuildReport = null;
+        if (displayNamesToFind != null) {
+            RunWrapper found = ReportSummaryUtil.findPreviousBuild(new File(job.asProject().getRootDir(), "weNeedPArent").toPath(), job.getLastBuild().getNumber(), PreviousBuilds.createPredicate(displayNamesToFind), settings.getIntMaxBuilds());
+            if (found != null) {
+                try {
+                    foundBuildReport = bsp.parseBuildReport(found);
+                } catch (Exception ex) {
+                    ex.printStackTrace();
+                }
+            }
+        }
         ProjectReport report = new ProjectReport(
                 reports,
                 collectImprovements(reports),
-                collectRegressions(reports));
+                collectRegressions(reports),
+                collectImprovementsAgainst(foundBuildReport, reports),
+                collectRegressionsAgainst(foundBuildReport, reports));
         return report;
     }
 
@@ -80,6 +101,9 @@ public class ReportProjectActionUtils  {
      * @return List of improvement counts, one for each report in reports
      */
     static List<Integer> collectImprovementsAgainst(BuildReport build, List<? extends BuildReport> reports) {
+        if (build == null) {
+            return Collections.emptyList();
+        }
         List<Integer> result = new ArrayList<>();
         Set<String> buildTests = collectTestNames(build);
 
@@ -130,6 +154,9 @@ public class ReportProjectActionUtils  {
      * @return List of regression counts, one for each report in reports
      */
     static List<Integer> collectRegressionsAgainst(BuildReport build, List<? extends BuildReport> reports) {
+        if (build == null) {
+            return Collections.emptyList();
+        }
         List<Integer> result = new ArrayList<>();
         Set<String> buildTests = collectTestNames(build);
 

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
@@ -46,7 +46,7 @@ public class ReportProjectActionUtils  {
     }
 
 
-    private static List<Integer> collectImprovements(List<? extends BuildReport> reports) {
+    static List<Integer> collectImprovements(List<? extends BuildReport> reports) {
         List<Integer> result = new ArrayList<>();
 
         Set<String> prev = null;
@@ -70,7 +70,7 @@ public class ReportProjectActionUtils  {
         return result;
     }
 
-    private static List<Integer> collectRegressions(List<? extends BuildReport> reports) {
+    static List<Integer> collectRegressions(List<? extends BuildReport> reports) {
         List<Integer> result = new ArrayList<>();
         Set<String> prev = null;
         for (BuildReport report : reports) {

--- a/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
+++ b/report-jtreg/src/main/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtils.java
@@ -70,6 +70,32 @@ public class ReportProjectActionUtils  {
         return result;
     }
 
+    /**
+     * Compares a single build against a list of builds to count improvements.
+     * For each report in reports, counts how many tests that failed in that report
+     * are no longer failing in the build parameter.
+     *
+     * @param build The build to compare against (typically an older build)
+     * @param reports List of builds to compare
+     * @return List of improvement counts, one for each report in reports
+     */
+    static List<Integer> collectImprovementsAgainst(BuildReport build, List<? extends BuildReport> reports) {
+        List<Integer> result = new ArrayList<>();
+        Set<String> buildTests = collectTestNames(build);
+
+        for (BuildReport report : reports) {
+            Set<String> reportTests = collectTestNames(report);
+            
+            long count = reportTests.stream()
+                    .sequential()
+                    .filter(s -> !buildTests.contains(s))
+                    .count();
+            result.add((int) count);
+        }
+
+        return result;
+    }
+
     static List<Integer> collectRegressions(List<? extends BuildReport> reports) {
         List<Integer> result = new ArrayList<>();
         Set<String> prev = null;
@@ -89,6 +115,32 @@ public class ReportProjectActionUtils  {
             result.add((int) count);
 
             prev = current;
+        }
+
+        return result;
+    }
+
+    /**
+     * Compares a single build against a list of builds to count regressions.
+     * For each report in reports, counts how many tests that are failing in the build parameter
+     * were not failing in that report.
+     *
+     * @param build The build to compare against (typically an older build)
+     * @param reports List of builds to compare
+     * @return List of regression counts, one for each report in reports
+     */
+    static List<Integer> collectRegressionsAgainst(BuildReport build, List<? extends BuildReport> reports) {
+        List<Integer> result = new ArrayList<>();
+        Set<String> buildTests = collectTestNames(build);
+
+        for (BuildReport report : reports) {
+            Set<String> reportTests = collectTestNames(report);
+            
+            long count = buildTests.stream()
+                    .sequential()
+                    .filter(s -> !reportTests.contains(s))
+                    .count();
+            result.add((int) count);
         }
 
         return result;

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
@@ -1,10 +1,11 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <l:layout title="${it.run} ${it.displayName}">
+    <l:layout title="${it.customTitle}">
         <l:main-panel>
             <a href="${it.previousLink}/">${it.previousLinkName}</a>
             ${it.buildNumber}
             <a href="${it.nextLink}/">${it.nextLinkName}</a> <br/>
+            Comparison against: ${it.comparedAgainstCaption}> <br/>
             <j:if test="${it.suites != null}">
                 <div class="jck">
                     <table>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/BuildReportExtendedPlugin/index.jelly
@@ -2,10 +2,19 @@
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:layout title="${it.customTitle}">
         <l:main-panel>
+            <j:choose>
+                <j:when test="${it.secondaryReport}">
+                    ${it.secondaryReportText} | <a href="${it.mainReportLink}">${it.mainReportText}</a>
+                </j:when>
+                <j:otherwise>
+                    <a href="${it.secondaryReportLink}">${it.secondaryReportText}</a> | ${it.mainReportText}
+                </j:otherwise>
+            </j:choose>
+            <br/>
             <a href="${it.previousLink}/">${it.previousLinkName}</a>
             ${it.buildNumber}
             <a href="${it.nextLink}/">${it.nextLinkName}</a> <br/>
-            Comparison against: ${it.comparedAgainstCaption}> <br/>
+            <a href="${it.comparedAgainstLink}/">Comparison against: ${it.comparedAgainstCaption}</a>
             <j:if test="${it.suites != null}">
                 <div class="jck">
                     <table>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ExactReportAction/summary.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ExactReportAction/summary.jelly
@@ -1,0 +1,11 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
+    <j:set var="report" value="${it.target}"/>
+    <j:if test="${report != null}">
+      <t:summary icon="clipboard.png">
+        <a href="${it.urlName}/">${it.displayName} against ${report.comparedAgainstCaption}</a>
+        <st:nbsp/>
+            Found comparison against set build.
+      </t:summary>
+    </j:if>
+</j:jelly>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/config.jelly
@@ -13,6 +13,9 @@
         <f:entry title="Exported kinds (comma-separated: PLAIN, JSON, PROPERTIES)" field="kinds">
             <f:textbox/>
         </f:entry>
+        <f:entry title="Display Name Comparison URL" field="displayNameComparisonURL">
+            <f:textbox/>
+        </f:entry>
     </f:section>
 
     <f:section title="Custom Tool Links (on top of a the report page)">

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-displayNameComparisonURL.html
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/JenkinsReportJckGlobalConfig/help-displayNameComparisonURL.html
@@ -1,0 +1,22 @@
+<div>
+    <p>
+        Specify the URL for the display name comparison. If this url is present, then except comparison agaisnt latest non-dfailed buildl, also gainst non-failed job with given displayName will be generated.
+    </p>
+    <p>
+        The URL must be a valid HTTP/HTTPS/FILE endpoint whcih returns the list of latest displayNames which we want to comapre against.
+    </p>
+    <p>
+        <b>Example:</b>
+    </p>
+    <ul>
+        <li><code>https://comparison-service.example.com/api/compare</code></li>
+        <li><code>file://some/config/latestReleasedDisplayNames</code></li>
+    </ul>
+    <p>
+        Note that first matched dispalyName is used. The maximmum number of jobs searched to past is reusded from jobs config "max points to show"
+    </p>
+    <p>
+        It is also causing second diff chart to be shown
+    </p>
+
+</div>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ReportAction/summary.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ReportAction/summary.jelly
@@ -1,9 +1,9 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:t="/lib/hudson">
     <t:summary icon="clipboard.png">
-        <a href="${it.urlName}/">${it.displayName}</a>
-        <st:nbsp/>
         <j:set var="report" value="${it.target}"/>
+        <a href="${it.urlName}/">${it.displayName} (against ${report.comparedAgainstCaption}) </a>
+        <st:nbsp/>
         <j:if test="${report != null}">
             Total: ${report.total}, Error: ${report.error}, Failed: ${report.failed}, Skipped: ${report.notRun}, Passed: ${report.passed}
         </j:if>

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ReportProjectAction/chartLogicBox.js
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ReportProjectAction/chartLogicBox.js
@@ -49,6 +49,20 @@
                 var jckdata_regs = jckdata_regs_element.textContent.split(/\s*,\s*/).flatMap((s) => (s.trim()));
         }
 
+        var jckdata_secondary_imps_element = document.getElementById('jckdata_secondary_imps');
+        if (jckdata_secondary_imps_element == null) {
+                var jckdata_secondary_imps = ["0"]
+        } else {
+                var jckdata_secondary_imps = jckdata_secondary_imps_element.textContent.split(/\s*,\s*/).flatMap((s) => (s.trim()));
+        }
+
+        var jckdata_secondary_regs_element = document.getElementById('jckdata_secondary_regs');
+        if (jckdata_secondary_regs_element == null) {
+                var jckdata_secondary_regs = ["0"]
+        } else {
+                var jckdata_secondary_regs = jckdata_secondary_regs_element.textContent.split(/\s*,\s*/).flatMap((s) => (s.trim()));
+        }
+
 
         var allJckFails = {
           type: 'line',
@@ -207,6 +221,56 @@
         };
         var ctx = document.getElementById("jckRegressionsChart").getContext("2d");
         var jckRegressions = new Chart(ctx, allJckRegressions);
+
+        var allJckSecondaryRegressions = {
+          type: 'bar',
+          data: {
+            labels: jckdata_builds,
+                datasets: [
+                {
+                label: "Secondary Improvements",
+                backgroundColor: "rgba(0,180,0,0.5)",
+                borderColor: "rgba(0,180,0,0.8)",
+                borderWidth: 2,
+                barThickness: 20,
+                hoverBackgroundColor: "rgba(0,180,0,0.75)",
+                hoverBorderColor: "rgba(0,180,0,1)",
+                        data: jckdata_secondary_imps
+                },
+                {
+                label: "Secondary Regressions",
+                backgroundColor: "rgba(180,0,0,0.5)",
+                borderColor: "rgba(180,0,0,0.8)",
+                borderWidth: 2,
+                barThickness: 20,
+                hoverBackgroundColor: "rgba(180,0,0,0.75)",
+                hoverBorderColor: "rgba(180,0,0,1)",
+                        data: jckdata_secondary_regs
+                }
+                ]
+        },
+        options: {
+          responsive: false,
+          plugins: {
+            legend: { display: false }
+          },
+          interaction: {
+            mode: 'index',
+            intersect: false
+          },
+           onClick: (e) => {
+                var activePoints = jckSecondaryRegressions.getElementsAtEventForMode(e, 'index', { intersect: false }, true);
+                var point = activePoints[0]
+                var datasetIndex = point.datasetIndex //labels are for all data together,  no need to look into exact dataset
+                var index = point.index
+                var result = jckSecondaryRegressions.config.data.labels[index]
+                var buildId = result.substring(result.lastIndexOf(":") + 1)
+                window.open("" + buildId + "/exact-java-reports", "_blank");
+           }
+         }
+        };
+        var ctx = document.getElementById("jckSecondaryRegressionsChart").getContext("2d");
+        var jckSecondaryRegressions = new Chart(ctx, allJckSecondaryRegressions);
 
         // ]]>
 

--- a/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ReportProjectAction/floatingBox.jelly
+++ b/report-jtreg/src/main/resources/io/jenkins/plugins/report/jtreg/ReportProjectAction/floatingBox.jelly
@@ -6,7 +6,9 @@
     <div id="jckPassedChartContainer" style="margin-right: 10pt"><canvas id='jckPassedChart' width='600' height='600'></canvas></div>
     <h3 style="font-family: monospace">Regressions: ${action.displayName}</h3>
     <div id="jckRegressionsChartContainer" style="margin-right: 10pt"><canvas id='jckRegressionsChart' width='600' height='600'></canvas></div>
-            <j:set var="jckReports" value="${action.chartData}" />
+    <j:set var="jckReports" value="${action.chartData}" />
+    <h3 style="font-family: monospace">Secondary Regressions (against ${jckReports.found}): ${action.displayName}</h3>
+    <div id="jckSecondaryRegressionsChartContainer" style="margin-right: 10pt"><canvas id='jckSecondaryRegressionsChart' width='600' height='600'></canvas></div>
 
     <span id="jckdata_builds" style="visibility:hidden">
         <j:forEach var="build" items="${jckReports.reports}" varStatus="status">
@@ -40,6 +42,16 @@
     </span>
     <span id="jckdata_regs" style="visibility:hidden">
         <j:forEach var="build" items="${jckReports.regressions}" varStatus="status">
+            ${build}<j:if test="${!status.last}">,</j:if>
+        </j:forEach>
+    </span>
+    <span id="jckdata_secondary_imps" style="visibility:hidden">
+        <j:forEach var="build" items="${jckReports.secondaryImprovements}" varStatus="status">
+            ${build}<j:if test="${!status.last}">,</j:if>
+        </j:forEach>
+    </span>
+    <span id="jckdata_secondary_regs" style="visibility:hidden">
+        <j:forEach var="build" items="${jckReports.secondaryRegressions}" varStatus="status">
             ${build}<j:if test="${!status.last}">,</j:if>
         </j:forEach>
     </span>

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
@@ -17,7 +17,7 @@ class BuildReportExtendedPluginTest {
                 new ArrayList<>(), new ArrayList<>(), 0, 0,
                 new SuitesWithResults(new ArrayList<>()),
                 "tck-jp17-ojdk17~rpms-el8.aarch64-fastdebug.sdk-el8.aarch64.beaker-x11.defaultgc.fips.lnxagent.jfroff",
-                -1, -1,
+                -1, -1, -1, null, -1, -1,
                 new UrlsProvider() {
                     @Override
                     public String getListServer() {

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/BuildReportExtendedPluginTest.java
@@ -33,7 +33,7 @@ class BuildReportExtendedPluginTest {
                     public String getDiffServer() {
                         return "http://mylocal" + Constants.DIFF_BACKEND;
                     }
-                });
+                }, "notyInterestedNow");
 
         // arguments without any wildcard
         LinkToComparator ltc = new LinkToComparator("", "comparator", "", "[.-]", "--arguments\n--without\n--any\n--wildcard");

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectImprovementsAgainstTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectImprovementsAgainstTest.java
@@ -1,0 +1,218 @@
+package io.jenkins.plugins.report.jtreg;
+
+import io.jenkins.plugins.report.jtreg.model.BuildReport;
+import io.jenkins.plugins.report.jtreg.model.Report;
+import io.jenkins.plugins.report.jtreg.model.Suite;
+import io.jenkins.plugins.report.jtreg.model.TestStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportProjectActionUtilsCollectImprovementsAgainstTest {
+
+    @Test
+    void testCollectImprovementsAgainst_emptyReportsList() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Collections.emptyList());
+        
+        assertEquals(0, improvements.size());
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_buildWithNoFailures() {
+        BuildReport build = createBuildReport(5, "Build5", Collections.emptyList());
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(createFailedTest("Suite1", "Test2")));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(1, improvements.get(0)); // Test1 from report1 is fixed in build
+        assertEquals(1, improvements.get(1)); // Test2 from report2 is fixed in build
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_buildWithSomeFailures() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite1", "Test2")));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(1, improvements.get(0)); // Test1 from report1 is fixed (Test2 still fails)
+        assertEquals(1, improvements.get(1)); // Test3 from report2 is fixed (Test2 still fails)
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_noImprovements() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(createFailedTest("Suite1", "Test2")));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(0, improvements.get(0)); // Test1 still fails in build
+        assertEquals(0, improvements.get(1)); // Test2 still fails in build
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_multipleImprovementsPerReport() {
+        BuildReport build = createBuildReport(5, "Build5", Collections.emptyList());
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite2", "Test4"),
+                createFailedTest("Suite2", "Test5")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(3, improvements.get(0)); // All 3 tests from report1 are fixed
+        assertEquals(2, improvements.get(1)); // Both tests from report2 are fixed
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_singleReport() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite1", "Test2")));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1));
+        
+        assertEquals(1, improvements.size());
+        assertEquals(2, improvements.get(0)); // Test1 and Test3 are fixed (Test2 still fails)
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_differentSuites() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite2", "Test2")));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite2", "Test2")
+            ));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite3", "Test3")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(1, improvements.get(0)); // Suite1/Test1 is fixed (Suite2/Test2 still fails)
+        assertEquals(1, improvements.get(1)); // Suite3/Test3 is fixed
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_allReportsHaveNoFailures() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        
+        BuildReport report1 = createBuildReport(1, "Build1", Collections.emptyList());
+        BuildReport report2 = createBuildReport(2, "Build2", Collections.emptyList());
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(0, improvements.get(0)); // No failures in report1 to fix
+        assertEquals(0, improvements.get(1)); // No failures in report2 to fix
+    }
+
+    @Test
+    void testCollectImprovementsAgainst_comparisonIsIndependent() {
+        // Each report is compared independently against build
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite1", "Test3")));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        BuildReport report3 = createBuildReport(3, "Build3",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovementsAgainst(
+            build, Arrays.asList(report1, report2, report3));
+        
+        assertEquals(3, improvements.size());
+        assertEquals(1, improvements.get(0)); // Test1 fixed (Test3 still fails)
+        assertEquals(1, improvements.get(1)); // Test2 fixed (Test3 still fails)
+        assertEquals(2, improvements.get(2)); // Test1 and Test2 fixed (Test3 still fails)
+    }
+
+    // Helper methods to create test data
+
+    private BuildReport createBuildReport(int buildNumber, String buildName, List<Suite> suites) {
+        return new BuildReport(buildNumber, buildName, 0, 0, 0, suites, 0, 0, 
+            System.currentTimeMillis(), 1000L);
+    }
+
+    private Suite createFailedTest(String suiteName, String testName) {
+        io.jenkins.plugins.report.jtreg.model.Test test = new io.jenkins.plugins.report.jtreg.model.Test(testName, TestStatus.FAILED, "Failed", Collections.emptyList());
+        Report report = new Report(0, 0, 1, 0, 1, Arrays.asList(test));
+        return new Suite(suiteName, report);
+    }
+}
+
+// Made with Bob

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectImprovementsTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectImprovementsTest.java
@@ -1,0 +1,185 @@
+package io.jenkins.plugins.report.jtreg;
+
+import io.jenkins.plugins.report.jtreg.model.BuildReport;
+import io.jenkins.plugins.report.jtreg.model.Report;
+import io.jenkins.plugins.report.jtreg.model.Suite;
+import io.jenkins.plugins.report.jtreg.model.TestStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportProjectActionUtilsCollectImprovementsTest {
+
+    @Test
+    void testCollectImprovements_emptyList() {
+        List<BuildReport> reports = Collections.emptyList();
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(reports);
+        assertEquals(0, improvements.size());
+    }
+
+    @Test
+    void testCollectImprovements_singleBuild() {
+        BuildReport report = createBuildReport(1, "Build1", 
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(Arrays.asList(report));
+        
+        assertEquals(1, improvements.size());
+        assertEquals(0, improvements.get(0)); // First build has no improvements
+    }
+
+    @Test
+    void testCollectImprovements_twoBuilds_oneTestFixed() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(0, improvements.get(0)); // First build
+        assertEquals(1, improvements.get(1)); // Test1 was fixed
+    }
+
+    @Test
+    void testCollectImprovements_threeBuilds_progressiveImprovements() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite2", "Test3")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite2", "Test3")
+            ));
+        
+        BuildReport report3 = createBuildReport(3, "Build3",
+            Arrays.asList(
+                createFailedTest("Suite2", "Test3")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(
+            Arrays.asList(report1, report2, report3));
+        
+        assertEquals(3, improvements.size());
+        assertEquals(0, improvements.get(0)); // First build
+        assertEquals(1, improvements.get(1)); // Test1 fixed
+        assertEquals(1, improvements.get(2)); // Test2 fixed
+    }
+
+    @Test
+    void testCollectImprovements_allTestsFixed() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2", Collections.emptyList());
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(0, improvements.get(0)); // First build
+        assertEquals(2, improvements.get(1)); // Both tests fixed
+    }
+
+    @Test
+    void testCollectImprovements_noImprovements() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(0, improvements.get(0)); // First build
+        assertEquals(0, improvements.get(1)); // No tests fixed
+    }
+
+    @Test
+    void testCollectImprovements_multipleSuites() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite2", "Test2"),
+                createFailedTest("Suite3", "Test3")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite2", "Test2")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(0, improvements.get(0)); // First build
+        assertEquals(2, improvements.get(1)); // Test1 and Test3 fixed
+    }
+
+    @Test
+    void testCollectImprovements_withNewFailures() {
+        // Build 1: Test1, Test2 fail
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        // Build 2: Test2, Test3 fail (Test1 fixed, Test3 new)
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        List<Integer> improvements = ReportProjectActionUtils.collectImprovements(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, improvements.size());
+        assertEquals(0, improvements.get(0)); // First build
+        assertEquals(1, improvements.get(1)); // Test1 fixed (Test3 is new, not an improvement)
+    }
+
+    // Helper methods to create test data
+
+    private BuildReport createBuildReport(int buildNumber, String buildName, List<Suite> suites) {
+        return new BuildReport(buildNumber, buildName, 0, 0, 0, suites, 0, 0, 
+            System.currentTimeMillis(), 1000L);
+    }
+
+    private Suite createFailedTest(String suiteName, String testName) {
+        io.jenkins.plugins.report.jtreg.model.Test test = new io.jenkins.plugins.report.jtreg.model.Test(testName, TestStatus.FAILED, "Failed", Collections.emptyList());
+        Report report = new Report(0, 0, 1, 0, 1, Arrays.asList(test));
+        return new Suite(suiteName, report);
+    }
+}
+
+// Made with Bob

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectRegressionsAgainstTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectRegressionsAgainstTest.java
@@ -1,0 +1,248 @@
+package io.jenkins.plugins.report.jtreg;
+
+import io.jenkins.plugins.report.jtreg.model.BuildReport;
+import io.jenkins.plugins.report.jtreg.model.Report;
+import io.jenkins.plugins.report.jtreg.model.Suite;
+import io.jenkins.plugins.report.jtreg.model.TestStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportProjectActionUtilsCollectRegressionsAgainstTest {
+
+    @Test
+    void testCollectRegressionsAgainst_emptyReportsList() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Collections.emptyList());
+        
+        assertEquals(0, regressions.size());
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_buildWithNoFailures() {
+        BuildReport build = createBuildReport(5, "Build5", Collections.emptyList());
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(createFailedTest("Suite1", "Test2")));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // No failures in build, so no regressions
+        assertEquals(0, regressions.get(1)); // No failures in build, so no regressions
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_buildWithNewFailures() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1", Collections.emptyList());
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(2, regressions.get(0)); // Both Test1 and Test2 are new in build compared to report1
+        assertEquals(1, regressions.get(1)); // Test2 is new in build compared to report2
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_noRegressions() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // Test1 was already failing in report1
+        assertEquals(0, regressions.get(1)); // Test1 was already failing in report2
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_multipleRegressionsPerReport() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3"),
+                createFailedTest("Suite2", "Test4")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1", Collections.emptyList());
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(4, regressions.get(0)); // All 4 tests are new compared to report1
+        assertEquals(2, regressions.get(1)); // Test3 and Test4 are new compared to report2
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_singleReport() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(createFailedTest("Suite1", "Test2")));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1));
+        
+        assertEquals(1, regressions.size());
+        assertEquals(2, regressions.get(0)); // Test1 and Test3 are new (Test2 was already failing)
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_differentSuites() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite2", "Test2"),
+                createFailedTest("Suite3", "Test3")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(createFailedTest("Suite2", "Test2")));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(2, regressions.get(0)); // Suite2/Test2 and Suite3/Test3 are new
+        assertEquals(2, regressions.get(1)); // Suite1/Test1 and Suite3/Test3 are new
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_allReportsHaveSameFailures() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // Same failures, no regressions
+        assertEquals(0, regressions.get(1)); // Same failures, no regressions
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_comparisonIsIndependent() {
+        // Each report is compared independently against build
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1", Collections.emptyList());
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        BuildReport report3 = createBuildReport(3, "Build3",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2, report3));
+        
+        assertEquals(3, regressions.size());
+        assertEquals(3, regressions.get(0)); // All 3 tests are new compared to report1
+        assertEquals(2, regressions.get(1)); // Test2 and Test3 are new compared to report2
+        assertEquals(1, regressions.get(2)); // Test3 is new compared to report3
+    }
+
+    @Test
+    void testCollectRegressionsAgainst_mixedScenario() {
+        BuildReport build = createBuildReport(5, "Build5",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(createFailedTest("Suite1", "Test3")));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressionsAgainst(
+            build, Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(1, regressions.get(0)); // Test3 is new (Test2 was already failing, Test1 was fixed)
+        assertEquals(1, regressions.get(1)); // Test2 is new (Test3 was already failing)
+    }
+
+    // Helper methods to create test data
+
+    private BuildReport createBuildReport(int buildNumber, String buildName, List<Suite> suites) {
+        return new BuildReport(buildNumber, buildName, 0, 0, 0, suites, 0, 0, 
+            System.currentTimeMillis(), 1000L);
+    }
+
+    private Suite createFailedTest(String suiteName, String testName) {
+        io.jenkins.plugins.report.jtreg.model.Test test = new io.jenkins.plugins.report.jtreg.model.Test(testName, TestStatus.FAILED, "Failed", Collections.emptyList());
+        Report report = new Report(0, 0, 1, 0, 1, Arrays.asList(test));
+        return new Suite(suiteName, report);
+    }
+}
+
+// Made with Bob

--- a/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectRegressionsTest.java
+++ b/report-jtreg/src/test/java/io/jenkins/plugins/report/jtreg/ReportProjectActionUtilsCollectRegressionsTest.java
@@ -1,0 +1,225 @@
+package io.jenkins.plugins.report.jtreg;
+
+import io.jenkins.plugins.report.jtreg.model.BuildReport;
+import io.jenkins.plugins.report.jtreg.model.Report;
+import io.jenkins.plugins.report.jtreg.model.Suite;
+import io.jenkins.plugins.report.jtreg.model.TestStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ReportProjectActionUtilsCollectRegressionsTest {
+
+    @Test
+    void testCollectRegressions_emptyList() {
+        List<BuildReport> reports = Collections.emptyList();
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(reports);
+        assertEquals(0, regressions.size());
+    }
+
+    @Test
+    void testCollectRegressions_singleBuild() {
+        BuildReport report = createBuildReport(1, "Build1",
+            Arrays.asList(createFailedTest("Suite1", "Test1")));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(Arrays.asList(report));
+        
+        assertEquals(1, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build has no regressions
+    }
+
+    @Test
+    void testCollectRegressions_twoBuilds_oneNewFailure() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(1, regressions.get(1)); // Test2 is new failure
+    }
+
+    @Test
+    void testCollectRegressions_threeBuilds_progressiveRegressions() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report3 = createBuildReport(3, "Build3",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite2", "Test3"),
+                createFailedTest("Suite2", "Test4")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2, report3));
+        
+        assertEquals(3, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(1, regressions.get(1)); // Test2 is new
+        assertEquals(2, regressions.get(2)); // Test3 and Test4 are new
+    }
+
+    @Test
+    void testCollectRegressions_noNewFailures() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(0, regressions.get(1)); // No new failures (Test2 was fixed)
+    }
+
+    @Test
+    void testCollectRegressions_allNewFailures() {
+        BuildReport report1 = createBuildReport(1, "Build1", Collections.emptyList());
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(2, regressions.get(1)); // Both tests are new failures
+    }
+
+    @Test
+    void testCollectRegressions_sameFailures() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(0, regressions.get(1)); // Same failures, no new ones
+    }
+
+    @Test
+    void testCollectRegressions_multipleSuites() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite2", "Test2"),
+                createFailedTest("Suite3", "Test3")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(2, regressions.get(1)); // Test2 and Test3 are new failures
+    }
+
+    @Test
+    void testCollectRegressions_withFixedTests() {
+        // Build 1: Test1, Test2 fail
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        // Build 2: Test2, Test3 fail (Test1 fixed, Test3 new)
+        BuildReport report2 = createBuildReport(2, "Build2",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test2"),
+                createFailedTest("Suite1", "Test3")
+            ));
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(1, regressions.get(1)); // Test3 is new (Test1 fixed is not a regression)
+    }
+
+    @Test
+    void testCollectRegressions_allTestsFixed() {
+        BuildReport report1 = createBuildReport(1, "Build1",
+            Arrays.asList(
+                createFailedTest("Suite1", "Test1"),
+                createFailedTest("Suite1", "Test2")
+            ));
+        
+        BuildReport report2 = createBuildReport(2, "Build2", Collections.emptyList());
+        
+        List<Integer> regressions = ReportProjectActionUtils.collectRegressions(
+            Arrays.asList(report1, report2));
+        
+        assertEquals(2, regressions.size());
+        assertEquals(0, regressions.get(0)); // First build
+        assertEquals(0, regressions.get(1)); // No new failures (all tests fixed)
+    }
+
+    // Helper methods to create test data
+
+    private BuildReport createBuildReport(int buildNumber, String buildName, List<Suite> suites) {
+        return new BuildReport(buildNumber, buildName, 0, 0, 0, suites, 0, 0, 
+            System.currentTimeMillis(), 1000L);
+    }
+
+    private Suite createFailedTest(String suiteName, String testName) {
+        io.jenkins.plugins.report.jtreg.model.Test test = new io.jenkins.plugins.report.jtreg.model.Test(testName, TestStatus.FAILED, "Failed", Collections.emptyList());
+        Report report = new Report(0, 0, 1, 0, 1, Arrays.asList(test));
+        return new Suite(suiteName, report);
+    }
+}
+
+// Made with Bob


### PR DESCRIPTION
This feature will add second report.
It will be diff agaisnt the latest released "displayName"

 * The url providing displayNames will be global config
 * the jobvs to past will be given by value in jobs, "max jobs to past to be shown"
 * only *diff* report is different for this second comparison\
   * becaue listing and failures are stillt he same
 * second diff chart is also generated